### PR TITLE
Allows for some type checking & autocomplete.

### DIFF
--- a/app/requests/FullScan.ts
+++ b/app/requests/FullScan.ts
@@ -135,6 +135,7 @@ export type ResponseType = {
   stack_size: number
   update_time: string // @todo datetime
   url: string // @todo URL
+  npc_vendor_info: string
 }
 
 const FullScanRequest: (map: FormValuesMap) => Promise<Response> = async (


### PR DESCRIPTION
## Why?

Fixes issue with an additional `columnHelper.accessor` referencing this field.
Typescript is pretty intelligent, in that it's currently showing a warning where this field is being used because we haven't let the system infer that there's actually a input of that name.

🪄 