### PR TITLE
add legacy link

### DIFF
--- a/app/components/navigation/sidebar/Sidebar.tsx
+++ b/app/components/navigation/sidebar/Sidebar.tsx
@@ -37,7 +37,7 @@ const navigation = [
   {
     name: 'Listings',
     href: 'queries/listings',
-    icon: ChartSquareBarIcon
+    icon: DocumentSearchIcon
   },
   {
     name: 'Item History',
@@ -47,7 +47,7 @@ const navigation = [
   {
     name: 'Legacy Site',
     href: 'https://saddlebag.exchange',
-    icon: PatreonIcon,
+    icon: HomeIcon,
     external: true
   },
   {

--- a/app/components/navigation/sidebar/Sidebar.tsx
+++ b/app/components/navigation/sidebar/Sidebar.tsx
@@ -45,6 +45,12 @@ const navigation = [
     icon: DocumentSearchIcon
   },
   {
+    name: 'Legacy Site',
+    href: 'https://saddlebag.exchange',
+    icon: PatreonIcon,
+    external: true
+  },
+  {
     name: 'Patreon',
     href: 'https://www.patreon.com/indopan',
     icon: PatreonIcon,
@@ -292,7 +298,7 @@ export const Sidebar: FC<Props> = ({ children, data }) => {
               <NavLink
                 className={`text-gray-300 text-base p-2 hover:bg-gray-700 hover:text-white `}
                 to={`/why/advertisements`}>
-                Advertisements
+                .
               </NavLink>
               {advertisements.map((item) => (
                 <a


### PR DESCRIPTION
## Why

We can run the legacy site on saddlebag.exchange for anyone who prefers that.  Apparently its way better for mobile. 