### PR TITLE
Task/table column reorder

### DIFF
--- a/app/components/form/SubmitButton/index.tsx
+++ b/app/components/form/SubmitButton/index.tsx
@@ -4,8 +4,12 @@ export const SubmitButton = ({
   title,
   onClick,
   loading,
-  disabled
-}: {
+  disabled,
+  ...rest
+}: React.DetailedHTMLProps<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  HTMLButtonElement
+> & {
   title: string
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
   loading?: boolean
@@ -19,7 +23,8 @@ export const SubmitButton = ({
       className={classNames(
         loading || disabled ? 'bg-gray-500' : 'bg-blue-600',
         'cursor-pointer ml-3 inline-flex justify-center items-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500'
-      )}>
+      )}
+      {...rest}>
       {loading && (
         <svg
           className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"

--- a/app/redux/localStorage/ffScanOrderHelpers.ts
+++ b/app/redux/localStorage/ffScanOrderHelpers.ts
@@ -1,8 +1,8 @@
 const FF_SCAN_ORDER_KEY = 'ff-scan-order'
 
 export const defaultSortOrder = [
-  'item_id',
   'real_name',
+  'item_id',
   'url',
   'npc_vendor_info',
   'server',
@@ -18,7 +18,7 @@ export const defaultSortOrder = [
   'home_update_time'
 ]
 
-export const getFFScanSortOrder = (): Array<string> => {
+export const getFFScanSortOrderInLocalStorage = (): Array<string> => {
   try {
     const sortOrder = localStorage.getItem(FF_SCAN_ORDER_KEY)
     if (!sortOrder) {
@@ -30,7 +30,7 @@ export const getFFScanSortOrder = (): Array<string> => {
   }
 }
 
-export const setFFScanSortOrder = (newOrder: Array<string>) => {
+export const setFFScanOrderInLocalStorage = (newOrder: Array<string>) => {
   try {
     localStorage.setItem(FF_SCAN_ORDER_KEY, JSON.stringify(newOrder))
     return { success: true }

--- a/app/redux/localStorage/ffScanOrderHelpers.ts
+++ b/app/redux/localStorage/ffScanOrderHelpers.ts
@@ -1,0 +1,40 @@
+const FF_SCAN_ORDER_KEY = 'ff-scan-order'
+
+export const defaultSortOrder = [
+  'item_id',
+  'real_name',
+  'url',
+  'npc_vendor_info',
+  'server',
+  'home_server_price',
+  'ppu',
+  'profit_amount',
+  'sale_rates',
+  'avg_ppu',
+  'ROI',
+  'profit_raw_percent',
+  'stack_size',
+  'update_time',
+  'home_update_time'
+]
+
+export const getFFScanSortOrder = (): Array<string> => {
+  try {
+    const sortOrder = localStorage.getItem(FF_SCAN_ORDER_KEY)
+    if (!sortOrder) {
+      return defaultSortOrder
+    }
+    return JSON.parse(sortOrder)
+  } catch {
+    return defaultSortOrder
+  }
+}
+
+export const setFFScanSortOrder = (newOrder: Array<string>) => {
+  try {
+    localStorage.setItem(FF_SCAN_ORDER_KEY, JSON.stringify(newOrder))
+    return { success: true }
+  } catch {
+    return undefined
+  }
+}

--- a/app/redux/reducers/queriesSlice.ts
+++ b/app/redux/reducers/queriesSlice.ts
@@ -4,7 +4,7 @@ import type { ListingResponseType } from '~/requests/GetListing'
 import type { HistoryResponse } from '~/requests/GetHistory'
 import type { ResponseType } from '~/requests/FullScan'
 
-type ScanResponse = Record<string, ResponseType>
+type ScanResponse = Array<ResponseType>
 
 export interface QueriesState {
   listings?: ListingResponseType

--- a/app/redux/reducers/userSlice.ts
+++ b/app/redux/reducers/userSlice.ts
@@ -4,7 +4,10 @@ import {
   getDarkModeFromLocalStorage,
   setDarkModeInLocalStorage
 } from '../localStorage/darkModeHelpers'
-import { getFFScanSortOrder } from '../localStorage/ffScanOrderHelpers'
+import {
+  getFFScanSortOrderInLocalStorage,
+  setFFScanOrderInLocalStorage
+} from '../localStorage/ffScanOrderHelpers'
 
 export interface UserState {
   darkmode: boolean
@@ -13,7 +16,7 @@ export interface UserState {
 
 const initialState: UserState = {
   darkmode: getDarkModeFromLocalStorage(),
-  ffScanSortOrder: getFFScanSortOrder()
+  ffScanSortOrder: getFFScanSortOrderInLocalStorage()
 }
 
 export const userSlice = createSlice({
@@ -31,7 +34,7 @@ export const userSlice = createSlice({
       state.darkmode = payload
     },
     setFFScanOrder: (state, { payload }: PayloadAction<Array<string>>) => {
-      setFFScanOrder(payload)
+      setFFScanOrderInLocalStorage(payload)
       state.ffScanSortOrder = payload
     }
   }

--- a/app/redux/reducers/userSlice.ts
+++ b/app/redux/reducers/userSlice.ts
@@ -4,13 +4,16 @@ import {
   getDarkModeFromLocalStorage,
   setDarkModeInLocalStorage
 } from '../localStorage/darkModeHelpers'
+import { getFFScanSortOrder } from '../localStorage/ffScanOrderHelpers'
 
 export interface UserState {
   darkmode: boolean
+  ffScanSortOrder: Array<string>
 }
 
 const initialState: UserState = {
-  darkmode: getDarkModeFromLocalStorage()
+  darkmode: getDarkModeFromLocalStorage(),
+  ffScanSortOrder: getFFScanSortOrder()
 }
 
 export const userSlice = createSlice({
@@ -26,10 +29,14 @@ export const userSlice = createSlice({
     setDarkMode: (state, { payload }: PayloadAction<boolean>) => {
       setDarkModeInLocalStorage(payload)
       state.darkmode = payload
+    },
+    setFFScanOrder: (state, { payload }: PayloadAction<Array<string>>) => {
+      setFFScanOrder(payload)
+      state.ffScanSortOrder = payload
     }
   }
 })
 
-export const { toggleDarkMode, setDarkMode } = userSlice.actions
+export const { toggleDarkMode, setDarkMode, setFFScanOrder } = userSlice.actions
 
 export default userSlice.reducer

--- a/app/routes/options/index.tsx
+++ b/app/routes/options/index.tsx
@@ -18,9 +18,8 @@ import { commitSession, getSession } from '~/sessions'
 import { Switch } from '@headlessui/react'
 import { classNames } from '~/utils'
 import { useDispatch } from 'react-redux'
-import { setFFScanOrder, toggleDarkMode } from '~/redux/reducers/userSlice'
+import { toggleDarkMode } from '~/redux/reducers/userSlice'
 import { useTypedSelector } from '~/redux/useTypedSelector'
-import { Draggable } from 'react-drag-reorder'
 
 export type SelectWorldInputFields = {
   data_center: GetDeepProp<DataCentersList, 'name'>
@@ -66,7 +65,7 @@ export default function () {
   const transition = useTransition()
   const actionData = useActionData()
   const dispatch = useDispatch()
-  const { darkmode, ffScanSortOrder } = useTypedSelector((state) => state.user)
+  const { darkmode } = useTypedSelector((state) => state.user)
 
   const handleDarkModeToggle = () => {
     dispatch(toggleDarkMode())
@@ -204,12 +203,6 @@ export default function () {
                     </div>
                   </div>
                 </div>
-                <ResultsTableOrder
-                  sortOrder={ffScanSortOrder}
-                  onOrderChange={(newOrder) =>
-                    dispatch(setFFScanOrder(newOrder))
-                  }
-                />
 
                 <div className="hidden sm:block" aria-hidden="true">
                   <div className="py-5">
@@ -221,65 +214,6 @@ export default function () {
           </div>
         </Form>
       </main>
-    </div>
-  )
-}
-
-const getUpdatedArray = (
-  currentPos: number,
-  newPos: number,
-  sortOrder: Array<string>
-): Array<string> | undefined => {
-  const itemToMove = sortOrder[currentPos]
-  if (!itemToMove) return
-
-  const result = sortOrder.reduce<Array<string>>(
-    (newOrder, columnId, currentIndex) => {
-      if (currentIndex !== currentPos && currentIndex !== newPos) {
-        return [...newOrder, columnId]
-      }
-
-      if (currentIndex === currentPos) {
-        return newOrder
-      }
-
-      return [...newOrder, itemToMove, columnId]
-    },
-    []
-  )
-  return result
-}
-
-const ResultsTableOrder = ({
-  sortOrder,
-  onOrderChange
-}: {
-  sortOrder: Array<string>
-  onOrderChange: (newList: Array<string>) => void
-}) => {
-  const handleColumnChange = (currentPosition: number, newPosition: number) => {
-    const newArray = getUpdatedArray(currentPosition, newPosition, sortOrder)
-    if (!newArray) {
-      return
-    }
-    onOrderChange(newArray)
-  }
-  return (
-    <div>
-      <p>Final Fantasy Scan Table Column Order</p>
-      <div className="flex-container">
-        <div className="row">
-          <Draggable onPosChange={handleColumnChange}>
-            {sortOrder.map((columnId, idx) => {
-              return (
-                <div key={idx} className="">
-                  <p>{columnId}</p>
-                </div>
-              )
-            })}
-          </Draggable>
-        </div>
-      </div>
     </div>
   )
 }

--- a/app/routes/queries/commodity-scan/index.tsx
+++ b/app/routes/queries/commodity-scan/index.tsx
@@ -66,10 +66,11 @@ const Index = () => {
     if (Object.keys(results).length === 0) {
       return <NoResults href={`/queries/full-scan`} />
     }
+    if ('data' in results) {
+      const data = results.data
 
-    const data = results.data
-
-    return <Results rows={data} />
+      return <Results rows={data} />
+    }
   }
   return (
     <main className="flex-1">
@@ -87,6 +88,7 @@ const Index = () => {
             defaultMinimumStackSize={2}
             defaultMinimumProfitAmount={1000}
             defaultPricePerUnit={1000}
+            error={results && results.exception ? results.exception : undefined}
           />
         </div>
       </div>

--- a/app/routes/queries/commodity-scan/index.tsx
+++ b/app/routes/queries/commodity-scan/index.tsx
@@ -14,7 +14,6 @@ import { useDispatch } from 'react-redux'
 import { useTypedSelector } from '~/redux/useTypedSelector'
 import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import FullScanForm from '../full-scan/FullScanForm'
-import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -50,7 +49,6 @@ const Index = () => {
   const dispatch = useDispatch()
 
   const commodityScan = useTypedSelector((state) => state.queries.commodityScan)
-  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   const onSubmit = (e: React.MouseEvent) => {
     if (transition.state === 'submitting') {
@@ -71,13 +69,7 @@ const Index = () => {
 
     const data = results.data
 
-    return (
-      <Results
-        rows={data}
-        sortOrder={sortOrder}
-        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
-      />
-    )
+    return <Results rows={data} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/commodity-scan/index.tsx
+++ b/app/routes/queries/commodity-scan/index.tsx
@@ -14,6 +14,7 @@ import { useDispatch } from 'react-redux'
 import { useTypedSelector } from '~/redux/useTypedSelector'
 import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import FullScanForm from '../full-scan/FullScanForm'
+import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -70,7 +71,13 @@ const Index = () => {
 
     const data = results.data
 
-    return <Results rows={data} sortOrder={sortOrder} />
+    return (
+      <Results
+        rows={data}
+        sortOrder={sortOrder}
+        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
+      />
+    )
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/commodity-scan/index.tsx
+++ b/app/routes/queries/commodity-scan/index.tsx
@@ -49,6 +49,7 @@ const Index = () => {
   const dispatch = useDispatch()
 
   const commodityScan = useTypedSelector((state) => state.queries.commodityScan)
+  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   const onSubmit = (e: React.MouseEvent) => {
     if (transition.state === 'submitting') {
@@ -69,7 +70,7 @@ const Index = () => {
 
     const data = results.data
 
-    return <Results rows={data} />
+    return <Results rows={data} sortOrder={sortOrder} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/fast-scan/index.tsx
+++ b/app/routes/queries/fast-scan/index.tsx
@@ -65,10 +65,11 @@ const Index = () => {
     if (Object.keys(results).length === 0) {
       return <NoResults href={`/queries/full-scan`} />
     }
+    if ('data' in results) {
+      const data = results.data
 
-    const data = results.data
-
-    return <Results rows={data} />
+      return <Results rows={data} />
+    }
   }
   return (
     <main className="flex-1">
@@ -86,6 +87,7 @@ const Index = () => {
             defaultSalesAmount={20}
             defaultMinimumProfitAmount={500}
             defaultPricePerUnit={500}
+            error={results && results.exception ? results.exception : undefined}
           />
         </div>
       </div>

--- a/app/routes/queries/fast-scan/index.tsx
+++ b/app/routes/queries/fast-scan/index.tsx
@@ -46,6 +46,8 @@ const Index = () => {
   const transition = useTransition()
   const results = useActionData()
   const fastScan = useTypedSelector((state) => state.queries.fastScan)
+  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
+
   const dispatch = useDispatch()
 
   const onSubmit = (e: React.MouseEvent) => {
@@ -67,7 +69,7 @@ const Index = () => {
 
     const data = results.data
 
-    return <Results rows={data} />
+    return <Results rows={data} sortOrder={sortOrder} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/fast-scan/index.tsx
+++ b/app/routes/queries/fast-scan/index.tsx
@@ -14,6 +14,7 @@ import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import { setFastScan } from '~/redux/reducers/queriesSlice'
 import { useDispatch } from 'react-redux'
 import FullScanForm from '../full-scan/FullScanForm'
+import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -69,7 +70,13 @@ const Index = () => {
 
     const data = results.data
 
-    return <Results rows={data} sortOrder={sortOrder} />
+    return (
+      <Results
+        rows={data}
+        sortOrder={sortOrder}
+        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
+      />
+    )
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/fast-scan/index.tsx
+++ b/app/routes/queries/fast-scan/index.tsx
@@ -14,7 +14,6 @@ import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import { setFastScan } from '~/redux/reducers/queriesSlice'
 import { useDispatch } from 'react-redux'
 import FullScanForm from '../full-scan/FullScanForm'
-import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -47,7 +46,6 @@ const Index = () => {
   const transition = useTransition()
   const results = useActionData()
   const fastScan = useTypedSelector((state) => state.queries.fastScan)
-  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   const dispatch = useDispatch()
 
@@ -70,13 +68,7 @@ const Index = () => {
 
     const data = results.data
 
-    return (
-      <Results
-        rows={data}
-        sortOrder={sortOrder}
-        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
-      />
-    )
+    return <Results rows={data} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/full-scan/DraggableHeader.tsx
+++ b/app/routes/queries/full-scan/DraggableHeader.tsx
@@ -17,11 +17,15 @@ const DraggableHeader = ({
   const ref = useRef()
   const { id } = column
 
-  const [, drop] = useDrop({
+  const [{ isOver }, drop] = useDrop({
     accept: ItemTypes.COLUMN,
     drop: (item) => {
       reorder(item, index)
-    }
+    },
+    collect: (monitor) => ({
+      isOver: monitor.isOver(),
+      isOverCurrent: monitor.isOver({ shallow: true })
+    })
   })
 
   const [{ isDragging }, drag, preview] = useDrag({
@@ -50,7 +54,8 @@ const DraggableHeader = ({
       {...rest}
       style={{
         cursor: 'move',
-        opacity: isDragging ? 0.5 : 1
+        opacity: isDragging ? 0.5 : 1,
+        outline: isOver ? 'solid 2px yellow' : 'none'
       }}>
       {children}
     </th>

--- a/app/routes/queries/full-scan/DraggableHeader.tsx
+++ b/app/routes/queries/full-scan/DraggableHeader.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from 'react'
+import { useDrop, useDrag } from 'react-dnd'
+import { getEmptyImage } from 'react-dnd-html5-backend'
+
+const ItemTypes = {
+  COLUMN: 'COLUMN',
+  ROW: 'ROW'
+}
+
+const DraggableHeader = ({
+  column,
+  index,
+  reorder,
+  children,
+  ...rest
+}: any) => {
+  const ref = useRef()
+  const { id } = column
+
+  const [, drop] = useDrop({
+    accept: ItemTypes.COLUMN,
+    drop: (item) => {
+      reorder(item, index)
+    }
+  })
+
+  const [{ isDragging }, drag, preview] = useDrag({
+    type: ItemTypes.COLUMN,
+    item: () => {
+      return {
+        id,
+        index,
+        stuff: column.column.columnDef.header
+      }
+    },
+    collect: (monitor) => ({
+      isDragging: monitor.isDragging()
+    })
+  })
+
+  drag(drop(ref))
+
+  useEffect(() => {
+    preview(getEmptyImage(), { captureDraggingState: true })
+  }, [preview])
+
+  return (
+    <th
+      ref={ref}
+      {...rest}
+      style={{
+        cursor: 'move',
+        opacity: isDragging ? 0.5 : 1
+      }}>
+      {children}
+    </th>
+  )
+}
+
+export default DraggableHeader

--- a/app/routes/queries/full-scan/DraggableHeader.tsx
+++ b/app/routes/queries/full-scan/DraggableHeader.tsx
@@ -51,12 +51,13 @@ const DraggableHeader = ({
   return (
     <th
       ref={ref}
-      {...rest}
       style={{
         cursor: 'move',
-        opacity: isDragging ? 0.5 : 1,
-        outline: isOver ? 'solid 2px yellow' : 'none'
-      }}>
+        outline: isOver ? 'solid 2px rgb(55 65 81)' : '',
+        opacity: isDragging || isOver ? 0.5 : 1,
+        borderRadius: '0.375rem'
+      }}
+      {...rest}>
       {children}
     </th>
   )

--- a/app/routes/queries/full-scan/FullScanForm.tsx
+++ b/app/routes/queries/full-scan/FullScanForm.tsx
@@ -16,7 +16,8 @@ const FullScanForm = ({
   defaultHQChecked = false,
   defaultRegionWideChecked = false,
   defaultIncludeVendorChecked = false,
-  defaultOutOfStockChecked = true
+  defaultOutOfStockChecked = true,
+  error
 }: {
   loading: boolean
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
@@ -31,6 +32,7 @@ const FullScanForm = ({
   defaultRegionWideChecked?: boolean
   defaultIncludeVendorChecked?: boolean
   defaultOutOfStockChecked?: boolean
+  error?: string
 }) => {
   const [ids, setIds] = useState(defaultFilters)
   const [isOpen, setIsOpen] = useState(false)
@@ -333,6 +335,7 @@ const FullScanForm = ({
         </div>
 
         <div className="flex justify-end">
+          {error && <p className="self-start text-red-500">{error}</p>}
           <SubmitButton title="Search" loading={loading} onClick={onClick} />
         </div>
       </Form>

--- a/app/routes/queries/full-scan/Preview.tsx
+++ b/app/routes/queries/full-scan/Preview.tsx
@@ -1,0 +1,30 @@
+import { useDragLayer } from 'react-dnd'
+
+const Preview = () => {
+  const { isDragging, item, currentOffset } = useDragLayer((monitor) => {
+    return {
+      item: monitor.getItem(),
+      itemType: monitor.getItemType(),
+      initialOffset: monitor.getInitialSourceClientOffset(),
+      currentOffset: monitor.getSourceClientOffset(),
+      isDragging: monitor.isDragging()
+    }
+  })
+
+  return isDragging ? (
+    <div
+      className="preview"
+      style={{
+        position: 'fixed',
+        pointerEvents: 'none',
+        left: 0,
+        top: 0,
+        transform: `translate(${currentOffset?.x}px, ${currentOffset?.y}px) rotate(5deg)`,
+        opacity: 0.8
+      }}>
+      {item.stuff}
+    </div>
+  ) : null
+}
+
+export default Preview

--- a/app/routes/queries/full-scan/Preview.tsx
+++ b/app/routes/queries/full-scan/Preview.tsx
@@ -13,14 +13,9 @@ const Preview = () => {
 
   return isDragging ? (
     <div
-      className="preview"
+      className="fixed pointer-events-none top-0 left-0 opacity-80"
       style={{
-        position: 'fixed',
-        pointerEvents: 'none',
-        left: 0,
-        top: 0,
-        transform: `translate(${currentOffset?.x}px, ${currentOffset?.y}px) rotate(5deg)`,
-        opacity: 0.8
+        transform: `translate(${currentOffset?.x}px, ${currentOffset?.y}px) rotate(5deg)`
       }}>
       {item.stuff}
     </div>

--- a/app/routes/queries/full-scan/Results.tsx
+++ b/app/routes/queries/full-scan/Results.tsx
@@ -230,12 +230,18 @@ const Results = ({ rows }: ResultTableProps) => {
                     aria-hidden="true"
                   />
                 </span>
-                <p className="ml-3 truncate font-medium text-white">
+                <p className="ml-3 truncate font-medium text-white flex flex-1 flex-col">
                   <span className="md:hidden">This is a wide table!</span>
+                  <span className="md:hidden">
+                    Drag a column name to move it!
+                  </span>
                   <span className="hidden md:inline">
                     Heads up, this table is pretty wide. You'll probably need to
-                    scroll horizontally (left & right). Click a column name to
-                    sort by that column.
+                    scroll horizontally (left & right).
+                  </span>
+                  <span className="hidden md:inline">
+                    Click a column name to sort by that column. Drag a column
+                    name to move it!
                   </span>
                 </p>
               </div>
@@ -258,7 +264,7 @@ const Results = ({ rows }: ResultTableProps) => {
           <div className="overflow-x-auto">
             <div className="inline-block min-w-full align-middle">
               <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
-                <table className="min-w-full divide-y divide-gray-300 mt-2">
+                <table className="min-w-full divide-y divide-gray-300 mt-2 bg-gray-50">
                   <thead className="bg-gray-50">
                     {table.getHeaderGroups().map((headerGroup) => (
                       <tr key={headerGroup.id}>

--- a/app/routes/queries/full-scan/Results.tsx
+++ b/app/routes/queries/full-scan/Results.tsx
@@ -244,6 +244,14 @@ const Results = ({ rows }: ResultTableProps) => {
         </div>
       </div>
 
+      <div className="max-w-fit my-2">
+        <SubmitButton
+          onClick={handleColumnReset}
+          title={'Reset table columns'}
+          type="button"
+        />
+      </div>
+
       <DndProvider
         backend={touchBackendRef.current ? TouchBackend : HTML5Backend}>
         <ScrollingComponent>
@@ -326,18 +334,11 @@ const Results = ({ rows }: ResultTableProps) => {
                   </tbody>
                 </table>
               </div>
-              <div className="flex flex-0 flex-col">
+              <div className="flex flex-0 ">
                 <p
                   className={`whitespace-nowrap px-3 py-4 text-sm text-gray-500`}>
                   {`${rows.length} results found`}
                 </p>
-                <div className="max-w-fit my-2">
-                  <SubmitButton
-                    onClick={handleColumnReset}
-                    title={'Reset table columns'}
-                    type="button"
-                  />
-                </div>
               </div>
             </div>
           </div>

--- a/app/routes/queries/full-scan/Results.tsx
+++ b/app/routes/queries/full-scan/Results.tsx
@@ -250,7 +250,7 @@ const Results = ({ rows }: ResultTableProps) => {
           <div className="overflow-x-auto">
             <div className="inline-block min-w-full align-middle">
               <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
-                <table className="min-w-full divide-y divide-gray-300">
+                <table className="min-w-full divide-y divide-gray-300 mt-2">
                   <thead className="bg-gray-50">
                     {table.getHeaderGroups().map((headerGroup) => (
                       <tr key={headerGroup.id}>
@@ -280,7 +280,7 @@ const Results = ({ rows }: ResultTableProps) => {
                                   header.column.getIsSorted()
                                     ? 'bg-gray-200 rounded bg-gray-200'
                                     : '',
-                                  ` ml-1 flex-none p-1`
+                                  ` ml-1 flex flex-0 p-1 justify-center items-center`
                                 )}>
                                 {{
                                   asc: (

--- a/app/routes/queries/full-scan/Results.tsx
+++ b/app/routes/queries/full-scan/Results.tsx
@@ -31,6 +31,7 @@ import FinalFantasyBadgedLink from '~/components/utilities/FinalFantasyBagdedLin
 
 type ResultTableProps = {
   rows: Array<ResponseType>
+  sortOrder: Array<string>
 }
 
 declare module '@tanstack/table-core' {
@@ -62,7 +63,7 @@ export const fuzzySort: SortingFn<any> = (rowA, rowB, columnId) => {
   return dir === 0 ? sortingFns.alphanumeric(rowA, rowB, columnId) : dir
 }
 
-const Results = ({ rows }: ResultTableProps) => {
+const Results = ({ rows, sortOrder }: ResultTableProps) => {
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [globalFilter, setGlobalFilter] = useState('')
   const [columnOrder, setColumnOrder] = useState<ColumnOrderState>([])
@@ -179,24 +180,8 @@ const Results = ({ rows }: ResultTableProps) => {
   }, [table])
 
   useEffect(() => {
-    setColumnOrder([
-      'real_name',
-      'item_id',
-      'url',
-      'npc_vendor_info',
-      'server',
-      'home_server_price',
-      'ppu',
-      'profit_amount',
-      'sale_rates',
-      'avg_ppu',
-      'ROI',
-      'profit_raw_percent',
-      'stack_size',
-      'update_time',
-      'home_update_time'
-    ])
-  }, [])
+    setColumnOrder(sortOrder)
+  }, [sortOrder])
 
   return (
     <div className={`mt-0 flex flex-col`}>

--- a/app/routes/queries/full-scan/getOrderedColumns.ts
+++ b/app/routes/queries/full-scan/getOrderedColumns.ts
@@ -1,0 +1,24 @@
+export const getOrderedColumns = (
+  currentPos: number,
+  newPos: number,
+  sortOrder: Array<string>
+): Array<string> | undefined => {
+  const itemToMove = sortOrder[currentPos]
+  if (!itemToMove) return
+
+  const result = sortOrder.reduce<Array<string>>(
+    (newOrder, columnId, currentIndex) => {
+      if (currentIndex !== currentPos && currentIndex !== newPos) {
+        return [...newOrder, columnId]
+      }
+
+      if (currentIndex === currentPos) {
+        return newOrder
+      }
+
+      return [...newOrder, itemToMove, columnId]
+    },
+    []
+  )
+  return result
+}

--- a/app/routes/queries/full-scan/getOrderedColumns.ts
+++ b/app/routes/queries/full-scan/getOrderedColumns.ts
@@ -7,28 +7,28 @@ export const getOrderedColumns = (
   if (!itemToMove) return
 
   const result = sortOrder.reduce<Array<string>>(
-    (newOrder, columnId, currentIndex) => {
-      // We are not at an item that needs swapping
+    (newOrder, currentItem, currentIndex) => {
       if (
+        // We are not at an item that needs swapping
         (currentIndex !== currentPos && currentIndex !== newPos) ||
         // item is placed on itself
         (currentIndex === newPos && currentPos === newPos)
       ) {
-        return [...newOrder, columnId]
+        return [...newOrder, currentItem]
       }
 
+      // Remove item that was moved
       if (currentIndex === currentPos) {
-        // we need to remove the item that is being moved
         return newOrder
       }
 
-      // if we are moving the item 1 place to the right then we need to swap them around.
+      // if we are moving the item 1 place to the right place it after the current item.
       if (currentIndex === newPos && currentPos + 1 === newPos) {
-        return [...newOrder, columnId, itemToMove]
+        return [...newOrder, currentItem, itemToMove]
       }
 
-      // else we need to drop in the moving item infront of the currently placed item
-      return [...newOrder, itemToMove, columnId]
+      // else drop the item in it's new position
+      return [...newOrder, itemToMove, currentItem]
     },
     []
   )

--- a/app/routes/queries/full-scan/getOrderedColumns.ts
+++ b/app/routes/queries/full-scan/getOrderedColumns.ts
@@ -8,14 +8,26 @@ export const getOrderedColumns = (
 
   const result = sortOrder.reduce<Array<string>>(
     (newOrder, columnId, currentIndex) => {
-      if (currentIndex !== currentPos && currentIndex !== newPos) {
+      // We are not at an item that needs swapping
+      if (
+        (currentIndex !== currentPos && currentIndex !== newPos) ||
+        // item is placed on itself
+        (currentIndex === newPos && currentPos === newPos)
+      ) {
         return [...newOrder, columnId]
       }
 
       if (currentIndex === currentPos) {
+        // we need to remove the item that is being moved
         return newOrder
       }
 
+      // if we are moving the item 1 place to the right then we need to swap them around.
+      if (currentIndex === newPos && currentPos + 1 === newPos) {
+        return [...newOrder, columnId, itemToMove]
+      }
+
+      // else we need to drop in the moving item infront of the currently placed item
       return [...newOrder, itemToMove, columnId]
     },
     []

--- a/app/routes/queries/full-scan/index.tsx
+++ b/app/routes/queries/full-scan/index.tsx
@@ -14,7 +14,6 @@ import { setFullScan } from '~/redux/reducers/queriesSlice'
 import { useTypedSelector } from '~/redux/useTypedSelector'
 import { PreviousResultsLink } from './PreviousResultsLink'
 import FullScanForm from './FullScanForm'
-import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -47,7 +46,6 @@ const Index = () => {
   const transition = useTransition()
   const results = useActionData()
   const fullScan = useTypedSelector((state) => state.queries.fullScan)
-  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   const dispatch = useDispatch()
 
@@ -70,13 +68,7 @@ const Index = () => {
 
     const data = results.data
 
-    return (
-      <Results
-        rows={data}
-        sortOrder={sortOrder}
-        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
-      />
-    )
+    return <Results rows={data} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/full-scan/index.tsx
+++ b/app/routes/queries/full-scan/index.tsx
@@ -65,10 +65,11 @@ const Index = () => {
     if (Object.keys(results).length === 0) {
       return <NoResults href={`/queries/full-scan`} />
     }
+    if ('data' in results) {
+      const data = results.data
 
-    const data = results.data
-
-    return <Results rows={data} />
+      return <Results rows={data} />
+    }
   }
   return (
     <main className="flex-1">
@@ -83,6 +84,9 @@ const Index = () => {
           <FullScanForm
             loading={transition.state === 'submitting'}
             onClick={onSubmit}
+            error={
+              results && 'exception' in results ? results.exception : undefined
+            }
           />
         </div>
       </div>

--- a/app/routes/queries/full-scan/index.tsx
+++ b/app/routes/queries/full-scan/index.tsx
@@ -46,6 +46,7 @@ const Index = () => {
   const transition = useTransition()
   const results = useActionData()
   const fullScan = useTypedSelector((state) => state.queries.fullScan)
+  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   const dispatch = useDispatch()
 
@@ -68,7 +69,7 @@ const Index = () => {
 
     const data = results.data
 
-    return <Results rows={data} />
+    return <Results rows={data} sortOrder={sortOrder} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/full-scan/index.tsx
+++ b/app/routes/queries/full-scan/index.tsx
@@ -14,6 +14,7 @@ import { setFullScan } from '~/redux/reducers/queriesSlice'
 import { useTypedSelector } from '~/redux/useTypedSelector'
 import { PreviousResultsLink } from './PreviousResultsLink'
 import FullScanForm from './FullScanForm'
+import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -69,7 +70,13 @@ const Index = () => {
 
     const data = results.data
 
-    return <Results rows={data} sortOrder={sortOrder} />
+    return (
+      <Results
+        rows={data}
+        sortOrder={sortOrder}
+        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
+      />
+    )
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/mega-value-scan/index.tsx
+++ b/app/routes/queries/mega-value-scan/index.tsx
@@ -48,6 +48,7 @@ const Index = () => {
   const dispatch = useDispatch()
 
   const megaValueScan = useTypedSelector((state) => state.queries.megaValueScan)
+  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   useEffect(() => {
     if (results && results.data) {
@@ -67,7 +68,7 @@ const Index = () => {
     }
     const data = results.data
 
-    return <Results rows={data} />
+    return <Results rows={data} sortOrder={sortOrder} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/mega-value-scan/index.tsx
+++ b/app/routes/queries/mega-value-scan/index.tsx
@@ -65,9 +65,11 @@ const Index = () => {
     if (Object.keys(results).length === 0) {
       return <NoResults href={`/queries/full-scan`} />
     }
-    const data = results.data
+    if ('data' in results) {
+      const data = results.data
 
-    return <Results rows={data} />
+      return <Results rows={data} />
+    }
   }
   return (
     <main className="flex-1">
@@ -91,6 +93,7 @@ const Index = () => {
             defaultRegionWideChecked={true}
             defaultIncludeVendorChecked={true}
             defaultOutOfStockChecked={true}
+            error={results && results.exception ? results.exception : undefined}
           />
         </div>
       </div>

--- a/app/routes/queries/mega-value-scan/index.tsx
+++ b/app/routes/queries/mega-value-scan/index.tsx
@@ -14,7 +14,6 @@ import { useTypedSelector } from '~/redux/useTypedSelector'
 import { setMegaValueScan } from '~/redux/reducers/queriesSlice'
 import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import FullScanForm from '../full-scan/FullScanForm'
-import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -49,7 +48,6 @@ const Index = () => {
   const dispatch = useDispatch()
 
   const megaValueScan = useTypedSelector((state) => state.queries.megaValueScan)
-  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   useEffect(() => {
     if (results && results.data) {
@@ -69,13 +67,7 @@ const Index = () => {
     }
     const data = results.data
 
-    return (
-      <Results
-        rows={data}
-        sortOrder={sortOrder}
-        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
-      />
-    )
+    return <Results rows={data} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/mega-value-scan/index.tsx
+++ b/app/routes/queries/mega-value-scan/index.tsx
@@ -14,6 +14,7 @@ import { useTypedSelector } from '~/redux/useTypedSelector'
 import { setMegaValueScan } from '~/redux/reducers/queriesSlice'
 import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import FullScanForm from '../full-scan/FullScanForm'
+import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -68,7 +69,13 @@ const Index = () => {
     }
     const data = results.data
 
-    return <Results rows={data} sortOrder={sortOrder} />
+    return (
+      <Results
+        rows={data}
+        sortOrder={sortOrder}
+        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
+      />
+    )
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/nq-out-stock-scan/index.tsx
+++ b/app/routes/queries/nq-out-stock-scan/index.tsx
@@ -13,6 +13,7 @@ import { useTypedSelector } from '~/redux/useTypedSelector'
 import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import { setNqOutOfStockScan } from '~/redux/reducers/queriesSlice'
 import FullScanForm from '../full-scan/FullScanForm'
+import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -69,7 +70,13 @@ const Index = () => {
     }
     const data = results.data
 
-    return <Results rows={data} sortOrder={sortOrder} />
+    return (
+      <Results
+        rows={data}
+        sortOrder={sortOrder}
+        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
+      />
+    )
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/nq-out-stock-scan/index.tsx
+++ b/app/routes/queries/nq-out-stock-scan/index.tsx
@@ -66,9 +66,11 @@ const Index = () => {
     if (Object.keys(results).length === 0) {
       return <NoResults href={`/queries/full-scan`} />
     }
-    const data = results.data
+    if ('data' in results) {
+      const data = results.data
 
-    return <Results rows={data} />
+      return <Results rows={data} />
+    }
   }
   return (
     <main className="flex-1">
@@ -95,6 +97,7 @@ const Index = () => {
             defaultFilters={[7, 54]}
             defaultIncludeVendorChecked={true}
             defaultOutOfStockChecked={true}
+            error={results && results.exception ? results.exception : undefined}
           />
         </div>
       </div>

--- a/app/routes/queries/nq-out-stock-scan/index.tsx
+++ b/app/routes/queries/nq-out-stock-scan/index.tsx
@@ -13,7 +13,6 @@ import { useTypedSelector } from '~/redux/useTypedSelector'
 import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import { setNqOutOfStockScan } from '~/redux/reducers/queriesSlice'
 import FullScanForm from '../full-scan/FullScanForm'
-import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -50,7 +49,6 @@ const Index = () => {
   const nqOutOfStockScan = useTypedSelector(
     (state) => state.queries.nqOutOfStockScan
   )
-  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   const onSubmit = (e: React.MouseEvent) => {
     if (transition.state === 'submitting') {
@@ -70,13 +68,7 @@ const Index = () => {
     }
     const data = results.data
 
-    return (
-      <Results
-        rows={data}
-        sortOrder={sortOrder}
-        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
-      />
-    )
+    return <Results rows={data} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/nq-out-stock-scan/index.tsx
+++ b/app/routes/queries/nq-out-stock-scan/index.tsx
@@ -49,6 +49,7 @@ const Index = () => {
   const nqOutOfStockScan = useTypedSelector(
     (state) => state.queries.nqOutOfStockScan
   )
+  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   const onSubmit = (e: React.MouseEvent) => {
     if (transition.state === 'submitting') {
@@ -68,7 +69,7 @@ const Index = () => {
     }
     const data = results.data
 
-    return <Results rows={data} />
+    return <Results rows={data} sortOrder={sortOrder} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/out-stock-scan/index.tsx
+++ b/app/routes/queries/out-stock-scan/index.tsx
@@ -14,6 +14,7 @@ import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import { useDispatch } from 'react-redux'
 import { setOutOfStockScan } from '~/redux/reducers/queriesSlice'
 import FullScanForm from '../full-scan/FullScanForm'
+import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -70,7 +71,13 @@ const Index = () => {
     }
     const data = results.data
 
-    return <Results rows={data} sortOrder={sortOrder} />
+    return (
+      <Results
+        rows={data}
+        sortOrder={sortOrder}
+        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
+      />
+    )
   }
 
   return (

--- a/app/routes/queries/out-stock-scan/index.tsx
+++ b/app/routes/queries/out-stock-scan/index.tsx
@@ -14,7 +14,6 @@ import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import { useDispatch } from 'react-redux'
 import { setOutOfStockScan } from '~/redux/reducers/queriesSlice'
 import FullScanForm from '../full-scan/FullScanForm'
-import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -49,7 +48,6 @@ const Index = () => {
   const outOfStockScan = useTypedSelector(
     (state) => state.queries.outOfStockScan
   )
-  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   const dispatch = useDispatch()
 
@@ -71,13 +69,7 @@ const Index = () => {
     }
     const data = results.data
 
-    return (
-      <Results
-        rows={data}
-        sortOrder={sortOrder}
-        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
-      />
-    )
+    return <Results rows={data} />
   }
 
   return (

--- a/app/routes/queries/out-stock-scan/index.tsx
+++ b/app/routes/queries/out-stock-scan/index.tsx
@@ -67,9 +67,12 @@ const Index = () => {
     if (Object.keys(results).length === 0) {
       return <NoResults href={`/queries/full-scan`} />
     }
-    const data = results.data
 
-    return <Results rows={data} />
+    if ('data' in results) {
+      const data = results.data
+
+      return <Results rows={data} />
+    }
   }
 
   return (
@@ -96,6 +99,7 @@ const Index = () => {
             defaultFilters={[1, 2, 3, 4, 7]}
             defaultHQChecked={true}
             defaultOutOfStockChecked={true}
+            error={results && results.exception ? results.exception : undefined}
           />
         </div>
       </div>

--- a/app/routes/queries/out-stock-scan/index.tsx
+++ b/app/routes/queries/out-stock-scan/index.tsx
@@ -48,6 +48,7 @@ const Index = () => {
   const outOfStockScan = useTypedSelector(
     (state) => state.queries.outOfStockScan
   )
+  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   const dispatch = useDispatch()
 
@@ -69,7 +70,7 @@ const Index = () => {
     }
     const data = results.data
 
-    return <Results rows={data} />
+    return <Results rows={data} sortOrder={sortOrder} />
   }
 
   return (

--- a/app/routes/queries/previous-search/index.tsx
+++ b/app/routes/queries/previous-search/index.tsx
@@ -5,6 +5,8 @@ import type { QueriesState } from '~/redux/reducers/queriesSlice'
 import { useTypedSelector } from '~/redux/useTypedSelector'
 import NoResults from './NoResults'
 import Results from '../full-scan/Results'
+import { setFFScanOrder } from '~/redux/reducers/userSlice'
+import { useDispatch } from 'react-redux'
 
 export const loader: LoaderFunction = ({ request }) => {
   const url = new URL(request.url)
@@ -18,6 +20,7 @@ const PreviousSearch = () => {
 
   const queries = useTypedSelector((state) => state.queries)
   const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
+  const dispatch = useDispatch()
 
   if (!data || !data.query) {
     return <NoResults href="/" />
@@ -31,7 +34,13 @@ const PreviousSearch = () => {
 
   const rowData = dataToUse
 
-  return <Results rows={rowData} sortOrder={sortOrder} />
+  return (
+    <Results
+      rows={rowData}
+      sortOrder={sortOrder}
+      onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
+    />
+  )
 }
 
 export default PreviousSearch

--- a/app/routes/queries/previous-search/index.tsx
+++ b/app/routes/queries/previous-search/index.tsx
@@ -5,8 +5,6 @@ import type { QueriesState } from '~/redux/reducers/queriesSlice'
 import { useTypedSelector } from '~/redux/useTypedSelector'
 import NoResults from './NoResults'
 import Results from '../full-scan/Results'
-import { setFFScanOrder } from '~/redux/reducers/userSlice'
-import { useDispatch } from 'react-redux'
 
 export const loader: LoaderFunction = ({ request }) => {
   const url = new URL(request.url)
@@ -19,8 +17,6 @@ const PreviousSearch = () => {
   const data = useLoaderData()
 
   const queries = useTypedSelector((state) => state.queries)
-  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
-  const dispatch = useDispatch()
 
   if (!data || !data.query) {
     return <NoResults href="/" />
@@ -34,13 +30,7 @@ const PreviousSearch = () => {
 
   const rowData = dataToUse
 
-  return (
-    <Results
-      rows={rowData}
-      sortOrder={sortOrder}
-      onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
-    />
-  )
+  return <Results rows={rowData} />
 }
 
 export default PreviousSearch

--- a/app/routes/queries/previous-search/index.tsx
+++ b/app/routes/queries/previous-search/index.tsx
@@ -17,6 +17,7 @@ const PreviousSearch = () => {
   const data = useLoaderData()
 
   const queries = useTypedSelector((state) => state.queries)
+  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   if (!data || !data.query) {
     return <NoResults href="/" />
@@ -30,7 +31,7 @@ const PreviousSearch = () => {
 
   const rowData = dataToUse
 
-  return <Results rows={rowData} />
+  return <Results rows={rowData} sortOrder={sortOrder} />
 }
 
 export default PreviousSearch

--- a/app/routes/queries/quest-scan/index.tsx
+++ b/app/routes/queries/quest-scan/index.tsx
@@ -66,9 +66,12 @@ const Index = () => {
     if (Object.keys(results).length === 0) {
       return <NoResults href={`/queries/full-scan`} />
     }
-    const data = results.data
 
-    return <Results rows={data} />
+    if ('data' in results) {
+      const data = results.data
+
+      return <Results rows={data} />
+    }
   }
   return (
     <main className="flex-1">
@@ -109,6 +112,7 @@ const Index = () => {
             defaultFilters={[-2, -3]}
             defaultIncludeVendorChecked={true}
             defaultOutOfStockChecked={true}
+            error={results && results.exception ? results.exception : undefined}
           />
         </div>
       </div>

--- a/app/routes/queries/quest-scan/index.tsx
+++ b/app/routes/queries/quest-scan/index.tsx
@@ -47,6 +47,7 @@ const Index = () => {
   const results = useActionData()
 
   const questScan = useTypedSelector((state) => state.queries.questScan)
+  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   const dispatch = useDispatch()
 
@@ -68,7 +69,7 @@ const Index = () => {
     }
     const data = results.data
 
-    return <Results rows={data} />
+    return <Results rows={data} sortOrder={sortOrder} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/quest-scan/index.tsx
+++ b/app/routes/queries/quest-scan/index.tsx
@@ -14,6 +14,7 @@ import { useDispatch } from 'react-redux'
 import { setQuestScan } from '~/redux/reducers/queriesSlice'
 import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import FullScanForm from '../full-scan/FullScanForm'
+import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -69,7 +70,13 @@ const Index = () => {
     }
     const data = results.data
 
-    return <Results rows={data} sortOrder={sortOrder} />
+    return (
+      <Results
+        rows={data}
+        sortOrder={sortOrder}
+        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
+      />
+    )
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/quest-scan/index.tsx
+++ b/app/routes/queries/quest-scan/index.tsx
@@ -14,7 +14,6 @@ import { useDispatch } from 'react-redux'
 import { setQuestScan } from '~/redux/reducers/queriesSlice'
 import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import FullScanForm from '../full-scan/FullScanForm'
-import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -48,7 +47,6 @@ const Index = () => {
   const results = useActionData()
 
   const questScan = useTypedSelector((state) => state.queries.questScan)
-  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   const dispatch = useDispatch()
 
@@ -70,13 +68,7 @@ const Index = () => {
     }
     const data = results.data
 
-    return (
-      <Results
-        rows={data}
-        sortOrder={sortOrder}
-        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
-      />
-    )
+    return <Results rows={data} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/value-scan/index.tsx
+++ b/app/routes/queries/value-scan/index.tsx
@@ -13,6 +13,7 @@ import { useDispatch } from 'react-redux'
 import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import { setValueScan } from '~/redux/reducers/queriesSlice'
 import FullScanForm from '../full-scan/FullScanForm'
+import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData()
@@ -68,7 +69,13 @@ const Index = () => {
     }
     const data = results.data
 
-    return <Results rows={data} sortOrder={sortOrder} />
+    return (
+      <Results
+        rows={data}
+        sortOrder={sortOrder}
+        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
+      />
+    )
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/value-scan/index.tsx
+++ b/app/routes/queries/value-scan/index.tsx
@@ -13,7 +13,6 @@ import { useDispatch } from 'react-redux'
 import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import { setValueScan } from '~/redux/reducers/queriesSlice'
 import FullScanForm from '../full-scan/FullScanForm'
-import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request }) => {
   const formData = await request.formData()
@@ -47,7 +46,6 @@ const Index = () => {
   const results = useActionData()
 
   const valueScan = useTypedSelector((state) => state.queries.valueScan)
-  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   const dispatch = useDispatch()
 
@@ -69,13 +67,7 @@ const Index = () => {
     }
     const data = results.data
 
-    return (
-      <Results
-        rows={data}
-        sortOrder={sortOrder}
-        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
-      />
-    )
+    return <Results rows={data} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/value-scan/index.tsx
+++ b/app/routes/queries/value-scan/index.tsx
@@ -65,9 +65,12 @@ const Index = () => {
     if (Object.keys(results).length === 0) {
       return <NoResults href={`/queries/full-scan`} />
     }
-    const data = results.data
 
-    return <Results rows={data} />
+    if ('data' in results) {
+      const data = results.data
+
+      return <Results rows={data} />
+    }
   }
   return (
     <main className="flex-1">
@@ -93,6 +96,7 @@ const Index = () => {
             defaultRegionWideChecked={true}
             defaultIncludeVendorChecked={false}
             defaultOutOfStockChecked={true}
+            error={results && results.exception ? results.exception : undefined}
           />
         </div>
       </div>

--- a/app/routes/queries/value-scan/index.tsx
+++ b/app/routes/queries/value-scan/index.tsx
@@ -46,6 +46,8 @@ const Index = () => {
   const results = useActionData()
 
   const valueScan = useTypedSelector((state) => state.queries.valueScan)
+  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
+
   const dispatch = useDispatch()
 
   const onSubmit = (e: React.MouseEvent) => {
@@ -66,7 +68,7 @@ const Index = () => {
     }
     const data = results.data
 
-    return <Results rows={data} />
+    return <Results rows={data} sortOrder={sortOrder} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/vendor-scan/index.tsx
+++ b/app/routes/queries/vendor-scan/index.tsx
@@ -13,7 +13,6 @@ import { useDispatch } from 'react-redux'
 import { setVendorScan } from '~/redux/reducers/queriesSlice'
 import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import FullScanForm from '../full-scan/FullScanForm'
-import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -47,7 +46,6 @@ const Index = () => {
   const results = useActionData()
 
   const vendorScan = useTypedSelector((state) => state.queries.vendorScan)
-  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
 
   const dispatch = useDispatch()
 
@@ -69,13 +67,7 @@ const Index = () => {
     }
     const data = results.data
 
-    return (
-      <Results
-        rows={data}
-        sortOrder={sortOrder}
-        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
-      />
-    )
+    return <Results rows={data} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/vendor-scan/index.tsx
+++ b/app/routes/queries/vendor-scan/index.tsx
@@ -13,6 +13,7 @@ import { useDispatch } from 'react-redux'
 import { setVendorScan } from '~/redux/reducers/queriesSlice'
 import { PreviousResultsLink } from '../full-scan/PreviousResultsLink'
 import FullScanForm from '../full-scan/FullScanForm'
+import { setFFScanOrder } from '~/redux/reducers/userSlice'
 
 export const action: ActionFunction = async ({ request, params }) => {
   const formData = await request.formData()
@@ -68,7 +69,13 @@ const Index = () => {
     }
     const data = results.data
 
-    return <Results rows={data} sortOrder={sortOrder} />
+    return (
+      <Results
+        rows={data}
+        sortOrder={sortOrder}
+        onReOrder={(newOrder) => dispatch(setFFScanOrder(newOrder))}
+      />
+    )
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/vendor-scan/index.tsx
+++ b/app/routes/queries/vendor-scan/index.tsx
@@ -44,7 +44,10 @@ export const ErrorBoundary: ErrorBoundaryComponent = ({ error }) => {
 const Index = () => {
   const transition = useTransition()
   const results = useActionData()
+
   const vendorScan = useTypedSelector((state) => state.queries.vendorScan)
+  const sortOrder = useTypedSelector((state) => state.user.ffScanSortOrder)
+
   const dispatch = useDispatch()
 
   useEffect(() => {
@@ -65,7 +68,7 @@ const Index = () => {
     }
     const data = results.data
 
-    return <Results rows={data} />
+    return <Results rows={data} sortOrder={sortOrder} />
   }
   return (
     <main className="flex-1">

--- a/app/routes/queries/vendor-scan/index.tsx
+++ b/app/routes/queries/vendor-scan/index.tsx
@@ -65,9 +65,12 @@ const Index = () => {
     if (Object.keys(results).length === 0) {
       return <NoResults href={`/queries/full-scan`} />
     }
-    const data = results.data
 
-    return <Results rows={data} />
+    if ('data' in results) {
+      const data = results.data
+
+      return <Results rows={data} />
+    }
   }
   return (
     <main className="flex-1">
@@ -93,6 +96,7 @@ const Index = () => {
             defaultRegionWideChecked={false}
             defaultIncludeVendorChecked={true}
             defaultOutOfStockChecked={true}
+            error={results && results.exception ? results.exception : undefined}
           />
         </div>
       </div>

--- a/app/routes/wow/full-scan/SmallTable.tsx
+++ b/app/routes/wow/full-scan/SmallTable.tsx
@@ -65,7 +65,7 @@ function SmallTable<Type>({
 
   const columnHelper = createColumnHelper<Type>()
 
-  const returnLocaleString = (value: any) => {
+  const parseToLocaleString = (value: any) => {
     if (typeof value === 'number') {
       return value.toLocaleString()
     }
@@ -84,9 +84,9 @@ function SmallTable<Type>({
         col.accessor
           ? col.accessor({
               row: props.row.original,
-              getValue: () => returnLocaleString(props.getValue())
+              getValue: () => parseToLocaleString(props.getValue())
             })
-          : returnLocaleString(props.getValue())
+          : parseToLocaleString(props.getValue())
     })
   })
 

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -803,6 +803,10 @@ select {
   right: 0.75rem;
 }
 
+.left-0 {
+  left: 0px;
+}
+
 .z-40 {
   z-index: 40;
 }
@@ -1326,6 +1330,10 @@ select {
   border-color: rgb(229 231 235 / var(--tw-divide-opacity));
 }
 
+.self-start {
+  align-self: flex-start;
+}
+
 .overflow-hidden {
   overflow: hidden;
 }
@@ -1826,6 +1834,10 @@ select {
 
 .opacity-100 {
   opacity: 1;
+}
+
+.opacity-80 {
+  opacity: 0.8;
 }
 
 .shadow {

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -1846,6 +1846,10 @@ select {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.outline {
+  outline-style: solid;
+}
+
 .ring-0 {
   --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
   --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -859,14 +859,14 @@ select {
   margin-right: 0.5rem;
 }
 
-.mx-3 {
-  margin-left: 0.75rem;
-  margin-right: 0.75rem;
-}
-
 .my-2 {
   margin-top: 0.5rem;
   margin-bottom: 0.5rem;
+}
+
+.mx-3 {
+  margin-left: 0.75rem;
+  margin-right: 0.75rem;
 }
 
 .my-1 {
@@ -1138,6 +1138,12 @@ select {
 
 .max-w-xs {
   max-width: 20rem;
+}
+
+.max-w-fit {
+  max-width: -webkit-fit-content;
+  max-width: -moz-fit-content;
+  max-width: fit-content;
 }
 
 .max-w-full {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,11 @@
     "highcharts": "^10.2.1",
     "highcharts-react-official": "^3.1.0",
     "react": "^18.2.0",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
+    "react-dnd-scrolling": "^1.2.4",
+    "react-dnd-touch-backend": "^16.0.1",
     "react-dom": "^18.2.0",
-    "react-drag-reorder": "^1.2.0",
     "react-redux": "^8.0.4",
     "remix-validated-form": "^4.5.5",
     "zod": "^3.19.1"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "highcharts-react-official": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-drag-reorder": "^1.2.0",
     "react-redux": "^8.0.4",
     "remix-validated-form": "^4.5.5",
     "zod": "^3.19.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7453,6 +7453,11 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-drag-reorder@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-drag-reorder/-/react-drag-reorder-1.2.0.tgz#218c55e9fdd83869d7ec9c6b9449494b28cbaded"
+  integrity sha512-UXpXvRYorBoJOIaniqDXtU/eKWx1YNk6D2efUk+awXAd2xNJS6DSdwEOrwUZU44XsjKYO54/QC1RmiaL2OqiEg==
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,6 +1616,21 @@
   dependencies:
     json-parse-even-better-errors "^2.3.1"
 
+"@react-dnd/asap@^5.0.1":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/asap/-/asap-5.0.2.tgz#1f81f124c1cd6f39511c11a881cfb0f715343488"
+  integrity sha512-WLyfoHvxhs0V9U+GTsGilGgf2QsPl6ZZ44fnv0/b8T3nQyvzxidxsg/ZltbWssbsRDlYW8UKSQMTGotuTotZ6A==
+
+"@react-dnd/invariant@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/invariant/-/invariant-4.0.2.tgz#b92edffca10a26466643349fac7cdfb8799769df"
+  integrity sha512-xKCTqAK/FFauOM9Ta2pswIyT3D8AQlfrYdOi/toTPEhqCuAs1v5tcJ3Y08Izh1cJ5Jchwy9SeAXmMg6zrKs2iw==
+
+"@react-dnd/shallowequal@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@react-dnd/shallowequal/-/shallowequal-4.0.2.tgz#d1b4befa423f692fa4abf1c79209702e7d8ae4b4"
+  integrity sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==
+
 "@reduxjs/toolkit@^1.8.6":
   version "1.8.6"
   resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.8.6.tgz#147fb7957befcdb75bc9c1230db63628e30e4332"
@@ -3484,6 +3499,15 @@ dlv@^1.1.3:
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
 
+dnd-core@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-16.0.1.tgz#a1c213ed08961f6bd1959a28bb76f1a868360d19"
+  integrity sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng==
+  dependencies:
+    "@react-dnd/asap" "^5.0.1"
+    "@react-dnd/invariant" "^4.0.1"
+    redux "^4.2.0"
+
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
@@ -4785,7 +4809,7 @@ history@^5.2.0, history@^5.3.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@3.x, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -5934,6 +5958,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
 lodash@^4.17.21:
   version "4.17.21"
@@ -7175,6 +7204,11 @@ peek-stream@^1.1.0:
     duplexify "^3.5.0"
     through2 "^2.0.3"
 
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
+
 periscopic@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/periscopic/-/periscopic-3.0.4.tgz#b3fbed0d1bc844976b977173ca2cd4a0ef4fa8d1"
@@ -7361,7 +7395,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.8.1:
+prop-types@15.x, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -7430,6 +7464,13 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
+raf@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
+  dependencies:
+    performance-now "^2.1.0"
+
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
@@ -7445,6 +7486,48 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-display-name@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/react-display-name/-/react-display-name-0.2.5.tgz#304c7cbfb59ee40389d436e1a822c17fe27936c6"
+  integrity sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg==
+
+react-dnd-html5-backend@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-16.0.1.tgz#87faef15845d512a23b3c08d29ecfd34871688b6"
+  integrity sha512-Wu3dw5aDJmOGw8WjH1I1/yTH+vlXEL4vmjk5p+MHxP8HuHJS1lAGeIdG/hze1AvNeXWo/JgULV87LyQOr+r5jw==
+  dependencies:
+    dnd-core "^16.0.1"
+
+react-dnd-scrolling@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/react-dnd-scrolling/-/react-dnd-scrolling-1.2.4.tgz#79f542152167b21b81ad1439e8f29e447830c2a8"
+  integrity sha512-twjfyP+S6cZu/ualBUAOHXiHTFATz0EmTwunP3KA4W4lNwTlp3lWJQtRWFlzPXYXY8sChRPfFb5psTgORFSVZA==
+  dependencies:
+    hoist-non-react-statics "3.x"
+    lodash.throttle "^4.1.1"
+    prop-types "15.x"
+    raf "^3.4.1"
+    react-display-name "^0.2.5"
+
+react-dnd-touch-backend@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd-touch-backend/-/react-dnd-touch-backend-16.0.1.tgz#e73f8169e2b9fac0f687970f875cac0a4d02d6e2"
+  integrity sha512-NonoCABzzjyWGZuDxSG77dbgMZ2Wad7eQiCd/ECtsR2/NBLTjGksPUx9UPezZ1nQ/L7iD130Tz3RUshL/ClKLA==
+  dependencies:
+    "@react-dnd/invariant" "^4.0.1"
+    dnd-core "^16.0.1"
+
+react-dnd@^16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-16.0.1.tgz#2442a3ec67892c60d40a1559eef45498ba26fa37"
+  integrity sha512-QeoM/i73HHu2XF9aKksIUuamHPDvRglEwdHL4jsp784BgUuWcg6mzfxT0QDdQz8Wj0qyRKx2eMg8iZtWvU4E2Q==
+  dependencies:
+    "@react-dnd/invariant" "^4.0.1"
+    "@react-dnd/shallowequal" "^4.0.1"
+    dnd-core "^16.0.1"
+    fast-deep-equal "^3.1.3"
+    hoist-non-react-statics "^3.3.2"
+
 react-dom@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
@@ -7452,11 +7535,6 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
-
-react-drag-reorder@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-drag-reorder/-/react-drag-reorder-1.2.0.tgz#218c55e9fdd83869d7ec9c6b9449494b28cbaded"
-  integrity sha512-UXpXvRYorBoJOIaniqDXtU/eKWx1YNk6D2efUk+awXAd2xNJS6DSdwEOrwUZU44XsjKYO54/QC1RmiaL2OqiEg==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
@@ -7567,7 +7645,7 @@ redux-thunk@^2.4.1:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.1.tgz#0dd8042cf47868f4b29699941de03c9301a75714"
   integrity sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==
 
-redux@^4.1.2:
+redux@^4.1.2, redux@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.0.tgz#46f10d6e29b6666df758780437651eeb2b969f13"
   integrity sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==


### PR DESCRIPTION
## Why

Allow users to reorder the FF Scan table. 
Users have given feedback that the table isn't great for mobile devices, allowing users to reorder the table will help them use the table on smaller devices.
