### PR TITLE
Feat/store session cookies locally

### DIFF
--- a/app/components/form/select/SelectWorld/index.tsx
+++ b/app/components/form/select/SelectWorld/index.tsx
@@ -14,11 +14,13 @@ type SelectWorldProps = PropsWithoutRef<{
   transition: Transition
   actionData: ValidationResult<SelectWorldInputFields>
   sessionData: SessionData
+  onChange?: (ffxiv: { world: string; data_center: string }) => void
 }>
 
 export const SelectDCandWorld: FC<SelectWorldProps> = ({
   transition,
-  sessionData
+  sessionData,
+  onChange
 }) => {
   const [dataCenter, setDataCenter] = useState<string | undefined>(
     sessionData.data_center
@@ -39,15 +41,26 @@ export const SelectDCandWorld: FC<SelectWorldProps> = ({
         Data Center
       </legend>
       <div className="mt-1 shadow-sm">
-        <SelectDataCenter onSelect={setDataCenter} dataCenter={dataCenter} />
+        <SelectDataCenter
+          onSelect={(data_center) => {
+            setDataCenter(data_center)
+            if (world && dataCenter) {
+              onChange?.({ world, data_center })
+            }
+          }}
+          dataCenter={dataCenter}
+        />
       </div>
       <div className={`mt-6`}>
         <legend className="block text-sm font-medium text-gray-700 dark:text-gray-100">
           World
         </legend>
         <SelectWorld
-          onSelect={(world) => {
-            setWorld(world)
+          onSelect={(newWorld) => {
+            setWorld(newWorld)
+            if (newWorld && dataCenter) {
+              onChange?.({ world: newWorld, data_center: dataCenter })
+            }
           }}
           dataCenter={dataCenter}
           world={world}

--- a/app/redux/localStorage/ffxivWorldDataHelpers.ts
+++ b/app/redux/localStorage/ffxivWorldDataHelpers.ts
@@ -1,0 +1,35 @@
+import { validateWorldAndDataCenter } from '~/utils/locations'
+
+const FFXIV_WORLD_KEY = 'ffxiv_world'
+const FFXIV_DATA_CENTER_KEY = 'ffxiv_data_center'
+
+export const getFFWorldDataFromLocalStorage = () => {
+  try {
+    const world = localStorage.getItem(FFXIV_WORLD_KEY)
+    const dataCenter = localStorage.getItem(FFXIV_DATA_CENTER_KEY)
+
+    const validData = validateWorldAndDataCenter(world, dataCenter)
+
+    if (!world || !dataCenter) {
+      setFFWorldDataInLocalStorage(validData.world, validData.data_center)
+    }
+
+    return validData
+  } catch {
+    return validateWorldAndDataCenter()
+  }
+}
+
+export const setFFWorldDataInLocalStorage = (
+  world: string,
+  dataCenter: string
+) => {
+  try {
+    localStorage.setItem(FFXIV_WORLD_KEY, world)
+    localStorage.setItem(FFXIV_DATA_CENTER_KEY, dataCenter)
+
+    return { success: true }
+  } catch {
+    return undefined
+  }
+}

--- a/app/redux/localStorage/wowRealmHelpers.ts
+++ b/app/redux/localStorage/wowRealmHelpers.ts
@@ -1,0 +1,47 @@
+import { validateServerAndRegion } from '~/utils/WoWServers'
+import z from 'zod'
+import type { WoWServerData, WoWServerRegion } from '~/requests/WoW/types'
+
+const WOW_REALM_KEY = 'wow_realm'
+const WOW_REGION_KEY = 'wow_region'
+
+const parseServer = z.object({
+  id: z.union([z.string(), z.number()]),
+  name: z.string()
+})
+
+const parseRegion = z.union([z.literal('NA'), z.literal('EU')])
+
+export const getWoWRealmDataFromLocalStorage = () => {
+  try {
+    const localserver = JSON.parse(
+      localStorage.getItem(WOW_REALM_KEY) || ` { "id": 3678, "name": 'Thrall' }`
+    )
+
+    const server = parseServer.parse(localserver)
+
+    const region = parseRegion.parse(localStorage.getItem(WOW_REGION_KEY))
+
+    const validData = validateServerAndRegion(region, server.id, server.name)
+
+    return validData
+  } catch {
+    const fallback = validateServerAndRegion('NA', undefined, undefined)
+    setWoWRealmDataInLocalStorage(fallback.server, fallback.region)
+    return validateServerAndRegion('NA', undefined, undefined)
+  }
+}
+
+export const setWoWRealmDataInLocalStorage = (
+  realm: WoWServerData,
+  region: WoWServerRegion
+) => {
+  try {
+    localStorage.setItem(WOW_REALM_KEY, JSON.stringify(realm))
+    localStorage.setItem(WOW_REGION_KEY, region)
+
+    return { success: true }
+  } catch {
+    return undefined
+  }
+}

--- a/app/redux/reducers/userSlice.ts
+++ b/app/redux/reducers/userSlice.ts
@@ -8,24 +8,29 @@ import {
   getFFScanSortOrderInLocalStorage,
   setFFScanOrderInLocalStorage
 } from '../localStorage/ffScanOrderHelpers'
-// import type { WoWServerRegion } from '~/requests/WOWScan'
 import {
   getFFWorldDataFromLocalStorage,
   setFFWorldDataInLocalStorage
 } from '../localStorage/ffxivWorldDataHelpers'
 import { validateWorldAndDataCenter } from '~/utils/locations'
+import {
+  getWoWRealmDataFromLocalStorage,
+  setWoWRealmDataInLocalStorage
+} from '../localStorage/wowRealmHelpers'
+import type { WoWServerData, WoWServerRegion } from '~/requests/WoW/types'
 
 export interface UserState {
   darkmode: boolean
   ffScanSortOrder: Array<string>
   ffxivWorld: { data_center: string; world: string }
-  // wowWorld: { server: { id: number; name: string }; region: WoWServerRegion }
+  wowRealm: { server: WoWServerData; region: WoWServerRegion }
 }
 
 const initialState: UserState = {
   darkmode: getDarkModeFromLocalStorage(),
   ffScanSortOrder: getFFScanSortOrderInLocalStorage(),
-  ffxivWorld: getFFWorldDataFromLocalStorage()
+  ffxivWorld: getFFWorldDataFromLocalStorage(),
+  wowRealm: getWoWRealmDataFromLocalStorage()
 }
 
 export const userSlice = createSlice({
@@ -56,11 +61,26 @@ export const userSlice = createSlice({
       )
       setFFWorldDataInLocalStorage(world, data_center)
       state.ffxivWorld = validateWorldAndDataCenter(world, data_center)
+    },
+    setWoWRealmData: (
+      state,
+      {
+        payload
+      }: PayloadAction<{ server: WoWServerData; region: WoWServerRegion }>
+    ) => {
+      setWoWRealmDataInLocalStorage(payload.server, payload.region)
+
+      state.wowRealm = payload
     }
   }
 })
 
-export const { toggleDarkMode, setDarkMode, setFFScanOrder, setFFxivWorld } =
-  userSlice.actions
+export const {
+  toggleDarkMode,
+  setDarkMode,
+  setFFScanOrder,
+  setFFxivWorld,
+  setWoWRealmData
+} = userSlice.actions
 
 export default userSlice.reducer

--- a/app/redux/reducers/userSlice.ts
+++ b/app/redux/reducers/userSlice.ts
@@ -8,15 +8,24 @@ import {
   getFFScanSortOrderInLocalStorage,
   setFFScanOrderInLocalStorage
 } from '../localStorage/ffScanOrderHelpers'
+// import type { WoWServerRegion } from '~/requests/WOWScan'
+import {
+  getFFWorldDataFromLocalStorage,
+  setFFWorldDataInLocalStorage
+} from '../localStorage/ffxivWorldDataHelpers'
+import { validateWorldAndDataCenter } from '~/utils/locations'
 
 export interface UserState {
   darkmode: boolean
   ffScanSortOrder: Array<string>
+  ffxivWorld: { data_center: string; world: string }
+  // wowWorld: { server: { id: number; name: string }; region: WoWServerRegion }
 }
 
 const initialState: UserState = {
   darkmode: getDarkModeFromLocalStorage(),
-  ffScanSortOrder: getFFScanSortOrderInLocalStorage()
+  ffScanSortOrder: getFFScanSortOrderInLocalStorage(),
+  ffxivWorld: getFFWorldDataFromLocalStorage()
 }
 
 export const userSlice = createSlice({
@@ -36,10 +45,22 @@ export const userSlice = createSlice({
     setFFScanOrder: (state, { payload }: PayloadAction<Array<string>>) => {
       setFFScanOrderInLocalStorage(payload)
       state.ffScanSortOrder = payload
+    },
+    setFFxivWorld: (
+      state,
+      { payload }: PayloadAction<{ data_center: string; world: string }>
+    ) => {
+      const { world, data_center } = validateWorldAndDataCenter(
+        payload.world,
+        payload.data_center
+      )
+      setFFWorldDataInLocalStorage(world, data_center)
+      state.ffxivWorld = validateWorldAndDataCenter(world, data_center)
     }
   }
 })
 
-export const { toggleDarkMode, setDarkMode, setFFScanOrder } = userSlice.actions
+export const { toggleDarkMode, setDarkMode, setFFScanOrder, setFFxivWorld } =
+  userSlice.actions
 
 export default userSlice.reducer

--- a/app/redux/reducers/userSlice.ts
+++ b/app/redux/reducers/userSlice.ts
@@ -18,6 +18,7 @@ import {
   setWoWRealmDataInLocalStorage
 } from '../localStorage/wowRealmHelpers'
 import type { WoWServerData, WoWServerRegion } from '~/requests/WoW/types'
+import { validateServerAndRegion } from '~/utils/WoWServers'
 
 export interface UserState {
   darkmode: boolean
@@ -68,9 +69,15 @@ export const userSlice = createSlice({
         payload
       }: PayloadAction<{ server: WoWServerData; region: WoWServerRegion }>
     ) => {
-      setWoWRealmDataInLocalStorage(payload.server, payload.region)
+      const { server, region } = validateServerAndRegion(
+        payload.region,
+        payload.server.id,
+        payload.server.name
+      )
 
-      state.wowRealm = payload
+      setWoWRealmDataInLocalStorage(server, region)
+
+      state.wowRealm = { server, region }
     }
   }
 })

--- a/app/routes/options/index.tsx
+++ b/app/routes/options/index.tsx
@@ -21,13 +21,18 @@ import {
 import { Switch } from '@headlessui/react'
 import { classNames } from '~/utils'
 import { useDispatch } from 'react-redux'
-import { setFFxivWorld, toggleDarkMode } from '~/redux/reducers/userSlice'
+import {
+  setFFxivWorld,
+  setWoWRealmData,
+  toggleDarkMode
+} from '~/redux/reducers/userSlice'
 import { useTypedSelector } from '~/redux/useTypedSelector'
 import React, { useState } from 'react'
 import { validateServerAndRegion } from '~/utils/WoWServers'
 import { validateWorldAndDataCenter } from '~/utils/locations'
 import RegionAndServerSelect from '~/components/form/WoW/RegionAndServerSelect'
 import SelectDCandWorld from '~/components/form/select/SelectWorld'
+import type { WoWServerData, WoWServerRegion } from '~/requests/WoW/types'
 
 export const validator = z.object({
   data_center: z.string().min(1),
@@ -156,6 +161,14 @@ export default function Options() {
     world: string
   }>({ data_center: data.data_center, world: data.world })
 
+  const [wowRealm, setWoWRealm] = useState<{
+    server: WoWServerData
+    region: WoWServerRegion
+  }>({
+    region: data.wowRegion,
+    server: data.wowRealm
+  })
+
   const handleDarkModeToggle = () => {
     dispatch(toggleDarkMode())
   }
@@ -171,6 +184,7 @@ export default function Options() {
               return
             }
             dispatch(setFFxivWorld(ffxivWorld))
+            dispatch(setWoWRealmData(wowRealm))
           }}>
           <div className="py-6">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8">
@@ -220,6 +234,16 @@ export default function Options() {
               region={data.wowRegion}
               defaultRealm={data.wowRealm}
               serverSelectFormName="homeRealm"
+              onServerSelectChange={(newServer) => {
+                if (newServer) {
+                  setWoWRealm((state) => ({ ...state, sever: newServer }))
+                }
+              }}
+              regionOnChange={(newRegion) => {
+                if (newRegion) {
+                  setWoWRealm((state) => ({ ...state, region: newRegion }))
+                }
+              }}
             />
           </OptionSection>
           <OptionSection

--- a/app/routes/options/index.tsx
+++ b/app/routes/options/index.tsx
@@ -21,9 +21,9 @@ import {
 import { Switch } from '@headlessui/react'
 import { classNames } from '~/utils'
 import { useDispatch } from 'react-redux'
-import { toggleDarkMode } from '~/redux/reducers/userSlice'
+import { setFFxivWorld, toggleDarkMode } from '~/redux/reducers/userSlice'
 import { useTypedSelector } from '~/redux/useTypedSelector'
-import React from 'react'
+import React, { useState } from 'react'
 import { validateServerAndRegion } from '~/utils/WoWServers'
 import { validateWorldAndDataCenter } from '~/utils/locations'
 import RegionAndServerSelect from '~/components/form/WoW/RegionAndServerSelect'
@@ -143,13 +143,18 @@ export const loader: LoaderFunction = async ({ request }) => {
   })
 }
 
-export default function () {
+export default function Options() {
   const data = useLoaderData()
   const transition = useTransition()
   const actionData = useActionData()
 
   const dispatch = useDispatch()
   const { darkmode } = useTypedSelector((state) => state.user)
+
+  const [ffxivWorld, setFfxivWorld] = useState<{
+    data_center: string
+    world: string
+  }>({ data_center: data.data_center, world: data.world })
 
   const handleDarkModeToggle = () => {
     dispatch(toggleDarkMode())
@@ -158,7 +163,15 @@ export default function () {
   return (
     <div>
       <main className="flex-1">
-        <Form method="post">
+        <Form
+          method="post"
+          onSubmit={(e) => {
+            if (transition.state === 'submitting') {
+              e.preventDefault()
+              return
+            }
+            dispatch(setFFxivWorld(ffxivWorld))
+          }}>
           <div className="py-6">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8">
               <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
@@ -195,6 +208,9 @@ export default function () {
               transition={transition}
               actionData={actionData}
               sessionData={data}
+              onChange={(newWorld) => {
+                setFfxivWorld(newWorld)
+              }}
             />
           </OptionSection>
           <OptionSection


### PR DESCRIPTION
## Why
Store session cookie locally and keep in sync so cloudflare deployments don't wipe user selections.

## Considerations
Some form of Auth & Database is probably our best practise here, might also remove a section of redux usage that feels against the grain to how remix should work.

