### PR TITLE
Add trademarks to sidebar

### DIFF
--- a/app/components/navigation/sidebar/Sidebar.tsx
+++ b/app/components/navigation/sidebar/Sidebar.tsx
@@ -445,6 +445,11 @@ export const Sidebar: FC<Props> = ({ children, data }) => {
                     <PatreonLink />
                     <WikiLink />
                     <DiscordLink />
+                    <p className="text-gray-400 text-xs mt-4">
+                      FINAL FANTASY is a registered trademark of Square Enix
+                      Holdings Co., Ltd.
+                      <br />© SQUARE ENIX CO., LTD. All Rights Reserved.
+                    </p>
                   </nav>
                 </div>
               </Dialog.Panel>
@@ -527,6 +532,11 @@ export const Sidebar: FC<Props> = ({ children, data }) => {
               <PatreonLink />
               <WikiLink />
               <DiscordLink />
+              <p className="text-gray-400 text-xs mt-4">
+                FINAL FANTASY is a registered trademark of Square Enix Holdings
+                Co., Ltd.
+                <br />© SQUARE ENIX CO., LTD. All Rights Reserved.
+              </p>
               <div id="ezoic-pub-ad-placeholder-118" />
             </nav>
           </div>

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -1985,6 +1985,11 @@ select {
   line-height: 1.75rem;
 }
 
+.text-xs {
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
 .font-bold {
   font-weight: 700;
 }


### PR DESCRIPTION
## Why

Adds the basic FFXIV trademark text to the sidebar to better match other XIV websites.
![image](https://github.com/ff14-advanced-market-search/saddlebag-with-pockets/assets/18511031/cf978f87-5a70-4dae-b2c5-1cddc15d7a60)


## Related Tickets

* Resolves https://github.com/ff14-advanced-market-search/saddlebag-with-pockets/issues/247


