### PR TITLE
Reverting the autosort on FFXIV listings

### DIFF
--- a/app/components/FFXIVResults/listings/ListingTable.tsx
+++ b/app/components/FFXIVResults/listings/ListingTable.tsx
@@ -100,7 +100,7 @@ const ListingTable = ({ data }: { data: ListingResponseType }) => {
     table.setSorting([
       {
         id: 'pricePerUnit',
-        desc: true
+        desc: false
       }
     ])
   }, [table])


### PR DESCRIPTION
## Why

Shows the lowest price on an item in the listing table for FFXIV items.

## Related Tickets

* Closes https://github.com/ff14-advanced-market-search/saddlebag-with-pockets/issues/251


