### PR TITLE
`Saddlebage` -> `Saddlebag` typo fix

### DIFF
--- a/app/routes/_public.price-sniper.tsx
+++ b/app/routes/_public.price-sniper.tsx
@@ -68,7 +68,7 @@ const Index = () => {
 
   const description = `To setup ${isPriceValue} alerts search, enter items and a desired
   ${isPriceValue}. Copy and paste the below input for the Discord Bot in the
-  Saddlebage Exchange discord server.`
+  Saddlebag Exchange discord server.`
 
   return (
     <PageWrapper>

--- a/app/routes/wow.price-alert.tsx
+++ b/app/routes/wow.price-alert.tsx
@@ -144,7 +144,7 @@ const Index = () => {
       <>
         <SmallFormContainer
           title={`WoW ${priceOrQuantity} alert input generator`}
-          description={`Generate the input for our World of Warcraft ${priceOrQuantity} alerts. Join the Saddlebage Exchange discord server to use this for the discord bot commands.`}
+          description={`Generate the input for our World of Warcraft ${priceOrQuantity} alerts. Join the Saddlebag Exchange discord server to use this for the discord bot commands.`}
           error={error}
           onClick={(e) => {
             e.preventDefault()


### PR DESCRIPTION
## Why

Fixed two instances where Saddlebag was referred to as Saddlebage in copy.