### PR TITLE
Bug/fix invalid ffxiv data center and world combination

### DIFF
--- a/app/components/form/select/SelectWorld/index.tsx
+++ b/app/components/form/select/SelectWorld/index.tsx
@@ -42,10 +42,13 @@ export const SelectDCandWorld: FC<SelectWorldProps> = ({
       </legend>
       <div className="mt-1 shadow-sm">
         <SelectDataCenter
-          onSelect={(data_center) => {
-            setDataCenter(data_center)
+          onSelect={(newDataCenter) => {
+            setDataCenter(newDataCenter)
+            const newWorld = Array.from(
+              locations.WorldsOfDataCenter(newDataCenter)
+            )[0].name
             if (world && dataCenter) {
-              onChange?.({ world, data_center })
+              onChange?.({ world: newWorld, data_center: newDataCenter })
             }
           }}
           dataCenter={dataCenter}

--- a/app/utils/locations/index.ts
+++ b/app/utils/locations/index.ts
@@ -2,7 +2,7 @@ import type { DataCentersList } from './DataCenters'
 import DataCenters, { DataCenterArray } from './DataCenters'
 import Regions from './Regions'
 import type { WorldsList } from './Worlds'
-import Worlds, { WorldsArray } from './Worlds'
+import Worlds, { WorldList, WorldsArray } from './Worlds'
 import {
   DataCenterNotFoundException,
   RegionNotFoundException
@@ -33,8 +33,13 @@ const validateWorldAndDataCenter = (
   world?: string | null,
   data_center?: string | null
 ): { world: string; data_center: string } => {
-  if (world && WorldsArray.includes(world)) {
-    if (data_center && DataCenterArray.includes(data_center)) {
+  if (data_center && DataCenterArray.includes(data_center)) {
+    if (
+      world &&
+      WorldList[data_center]
+        ?.map((validWorld) => validWorld.name)
+        .includes(world)
+    ) {
       return { world, data_center }
     }
   }


### PR DESCRIPTION
## Why

Fix bug causing invalid FFXIV data center and world combinations.




## Considerations

Additional context/info.
Changing just the data center causes the world to not update in local storage. 

https://github.com/ff14-advanced-market-search/saddlebag-with-pockets/assets/50222178/67faef6c-f89e-4c4f-825b-b05bc44f435d

When reloading the site or opening in a new tab, users are redirected to the root route '/' no matter what page they're on and the invalid data center/world combination is loaded from local storage.

https://github.com/ff14-advanced-market-search/saddlebag-with-pockets/assets/50222178/0ebd3ff0-146d-46f7-a4e1-27544bca1610

