### PR TITLE
Task/add sale alert json to undercut generator

### DIFF
--- a/app/components/FFXIVResults/UndercutAlert/Results.tsx
+++ b/app/components/FFXIVResults/UndercutAlert/Results.tsx
@@ -135,7 +135,7 @@ const Results = ({
               />
             </div>
 
-
+            
             <pre className="overflow-x-scroll bg-slate-700 text-gray-200 p-4 rounded dark:bg-slate-900">
               <code>{jsonData}</code>
             </pre>
@@ -160,6 +160,8 @@ const Results = ({
               />
             </div>
             
+            <Title title="Input for Sales Alerts" />
+            <SalesAlertDescription/>
             <pre className="overflow-x-scroll bg-slate-700 text-gray-200 p-4 rounded dark:bg-slate-900">
               <code>{salesAlertJson}</code>
             </pre>
@@ -249,6 +251,7 @@ const Results = ({
 
 export default Results
 
+// TODO: rework both these into 1 component to prevent redundant code
 export const UndercutDescription = () => (
   <p className="italic text-sm text-grey-500 mb-1 dark:text-gray-300">
     Copy this to your clipboard and use it in our{' '}
@@ -266,6 +269,27 @@ export const UndercutDescription = () => (
       target="_blank"
       rel="noreferrer">
       patreon undercut alerts.
+    </a>
+  </p>
+)
+
+export const SalesAlertDescription = () => (
+  <p className="italic text-sm text-grey-500 mb-1 dark:text-gray-300">
+    To use Sales Alerts copy this to your clipboard and use it in our{' '}
+    <a
+      className="underline"
+      href="https://discord.gg/836C8wDVNq"
+      target="_blank"
+      rel="noreferrer">
+      discord server
+    </a>{' '}
+    for the bot slash command '/ff sale-register' to activate {' '}
+    <a
+      className="underline"
+      href="https://github.com/ff14-advanced-market-search/saddlebag-with-pockets/wiki/Allagan-Tools-Inventory-Analysis#sale-and-undercut-alert-json-data"
+      target="_blank"
+      rel="noreferrer">
+      patreon sale alerts.
     </a>
   </p>
 )

--- a/app/components/FFXIVResults/UndercutAlert/Results.tsx
+++ b/app/components/FFXIVResults/UndercutAlert/Results.tsx
@@ -42,6 +42,7 @@ const Results = ({
   )}],\n  "hq_only": ${info.hqOnly.toString()},\n  "ignore_data_after_hours": ${
     info.ignoreDataAfterHours
   },\n  "ignore_undercuts_with_quantity_over": ${info.ignoreStackSize}\n}`
+  const salesAlertJson =  `{\n  "seller_id": "${sellerId}",\n  "server": "${homeServer}",\n  "item_ids": []\n}`
 
   const isAddModal = modal.form === 'addIds'
   return (
@@ -134,6 +135,7 @@ const Results = ({
               />
             </div>
 
+
             <pre className="overflow-x-scroll bg-slate-700 text-gray-200 p-4 rounded dark:bg-slate-900">
               <code>{jsonData}</code>
             </pre>
@@ -157,6 +159,31 @@ const Results = ({
                 }}
               />
             </div>
+            
+            <pre className="overflow-x-scroll bg-slate-700 text-gray-200 p-4 rounded dark:bg-slate-900">
+              <code>{salesAlertJson}</code>
+            </pre>
+            <div className="max-w-fit my-2">
+              <SubmitButton
+                title="Copy to clipboard"
+                type="button"
+                disabled={isAddModal && info.addIds.length === 0}
+                onClick={async () => {
+                  if (
+                    typeof window !== 'undefined' &&
+                    typeof document !== 'undefined'
+                  ) {
+                    if (!window.isSecureContext) {
+                      alert('Unable to copy.')
+                      return
+                    }
+                    await navigator.clipboard.writeText(salesAlertJson)
+                    alert('Copied to clipboard!')
+                  }
+                }}
+              />
+            </div>
+
           </div>
           {modal.open && (
             <Modal

--- a/app/components/FFXIVResults/UndercutAlert/Results.tsx
+++ b/app/components/FFXIVResults/UndercutAlert/Results.tsx
@@ -42,7 +42,7 @@ const Results = ({
   )}],\n  "hq_only": ${info.hqOnly.toString()},\n  "ignore_data_after_hours": ${
     info.ignoreDataAfterHours
   },\n  "ignore_undercuts_with_quantity_over": ${info.ignoreStackSize}\n}`
-  const salesAlertJson =  `{\n  "seller_id": "${sellerId}",\n  "server": "${homeServer}",\n  "item_ids": []\n}`
+  const salesAlertJson = `{\n  "seller_id": "${sellerId}",\n  "server": "${homeServer}",\n  "item_ids": []\n}`
 
   const isAddModal = modal.form === 'addIds'
   return (
@@ -135,7 +135,6 @@ const Results = ({
               />
             </div>
 
-            
             <pre className="overflow-x-scroll bg-slate-700 text-gray-200 p-4 rounded dark:bg-slate-900">
               <code>{jsonData}</code>
             </pre>
@@ -159,9 +158,9 @@ const Results = ({
                 }}
               />
             </div>
-            
+
             <Title title="Input for Sales Alerts" />
-            <SalesAlertDescription/>
+            <SalesAlertDescription />
             <pre className="overflow-x-scroll bg-slate-700 text-gray-200 p-4 rounded dark:bg-slate-900">
               <code>{salesAlertJson}</code>
             </pre>
@@ -185,7 +184,6 @@ const Results = ({
                 }}
               />
             </div>
-
           </div>
           {modal.open && (
             <Modal
@@ -283,7 +281,7 @@ export const SalesAlertDescription = () => (
       rel="noreferrer">
       discord server
     </a>{' '}
-    for the bot slash command '/ff sale-register' to activate {' '}
+    for the bot slash command '/ff sale-register' to activate{' '}
     <a
       className="underline"
       href="https://github.com/ff14-advanced-market-search/saddlebag-with-pockets/wiki/Allagan-Tools-Inventory-Analysis#sale-and-undercut-alert-json-data"


### PR DESCRIPTION
## Why

Adds title with description and input for Sales Alert JSON to Undercut Generator page, once the input for Undercut alerts JSON has been generated.


## Related Tickets

* Closes [Add sale alert json to undercut generator #336](https://github.com/ff14-advanced-market-search/saddlebag-with-pockets/issues/336) 


## Considerations

* Consider creating 1 component so we don't have redundant code for the descriptions for each JSON generated.

<img width="1308" alt="Screenshot 2023-12-02 at 2 56 49 PM" src="https://github.com/ff14-advanced-market-search/saddlebag-with-pockets/assets/46858378/ee7f38d8-b75c-432c-a885-13c04bb44ff9">


