### PR TITLE
Accepted floats for sales per day

### DIFF
--- a/app/components/form/WoW/MarketshareForm/index.tsx
+++ b/app/components/form/WoW/MarketshareForm/index.tsx
@@ -40,7 +40,7 @@ const MarketShareForm = ({
         inputTag="Sales"
         name="desiredSalesPerDay"
         min={0}
-        step={1}
+        step={0.01}
       />
       <RegionAndServerSelect
         region={regionDefault}

--- a/app/components/form/WoW/WoWScanForm.tsx
+++ b/app/components/form/WoW/WoWScanForm.tsx
@@ -89,6 +89,7 @@ const WoWScanForm = ({
           <InputWithLabel
             defaultValue={0}
             type="number"
+            step="0.01"
             labelTitle="Minimum Sales Per Day"
             inputTag="Min Sales"
             name="salePerDay"

--- a/app/routes/wow.shortages.commodities.tsx
+++ b/app/routes/wow.shortages.commodities.tsx
@@ -240,6 +240,7 @@ export const WoWShortageFormFields = ({
     <InputWithLabel
       defaultValue={desiredSalesPerDayDefault}
       type="number"
+      step="0.01"
       labelTitle="Desired Sales per Day"
       inputTag="Sales"
       name="desiredSalesPerDay"


### PR DESCRIPTION
closes: https://github.com/ff14-advanced-market-search/saddlebag-with-pockets/issues/387

## Why

Brief description/reasons for PR

Accepted floats for sales to 2 decimal places for sales per day.
