### PR TITLE
docs: updated run server command for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The frontend of https://saddlebagexchange.com/
 
-Last udated for FFXIV 6.51
+Last updated for FFXIV 6.51
 
 _Frontend for Aetheryte API_
 
@@ -24,6 +24,12 @@ Run Server:
 
 ```bash
 yarn run dev
+```
+
+For Windows:
+
+```bash
+yarn dev
 ```
 
 This starts your app in development mode, rebuilding assets on file changes.


### PR DESCRIPTION
## Why

To ensure clarity and usability for developers on Windows platforms, the README has been updated to include the correct command for running the server. This adjustment helps prevent potential confusion and streamlines the setup process for Windows users.

## Added

Updated the "Run Server" section in the README to include yarn dev specifically for Windows users alongside the existing command for non-Windows platforms.

## Related Tickets

N/A

## Considerations

N/A

