### PR TITLE
Add support for URL search parameters

### DIFF
--- a/app/components/form/WoW/MarketshareForm/index.tsx
+++ b/app/components/form/WoW/MarketshareForm/index.tsx
@@ -4,7 +4,7 @@ import CheckBox from '../../CheckBox'
 import { InputWithLabel } from '../../InputWithLabel'
 import RegionAndServerSelect from '../RegionAndServerSelect'
 import { ItemClassSelect, ItemQualitySelect } from '../WoWScanForm'
-import { defaultFormValuesMarketShare } from '~/routes/wow.marketshare'
+import type { defaultFormValuesMarketShare } from '~/routes/wow.marketshare'
 
 const MarketShareForm = ({
   loaderData,

--- a/app/routes/wow.shortage-predictor.tsx
+++ b/app/routes/wow.shortage-predictor.tsx
@@ -5,7 +5,7 @@ import {
   ItemClassSelect,
   ItemQualitySelect
 } from '~/components/form/WoW/WoWScanForm'
-import type { WoWLoaderData } from '~/requests/WoW/types'
+import type { WoWServerData } from '~/requests/WoW/types'
 import { InputWithLabel } from '~/components/form/InputWithLabel'
 import type { ActionFunction, LoaderFunction } from '@remix-run/cloudflare'
 import { json } from '@remix-run/cloudflare'
@@ -19,18 +19,40 @@ import NoResults from '~/components/Common/NoResults'
 import RegionAndServerSelect from '~/components/form/WoW/RegionAndServerSelect'
 import { getUserSessionData } from '~/sessions'
 import { Results } from '~/components/WoWResults/ShortagePredictor/Results'
+import { parseStringToNumber } from '~/utils/zodHelpers'
+import { useState } from 'react'
+import type { WoWServerRegion } from '~/requests/WOWScan'
+import {
+  getActionUrl,
+  handleCopyButton,
+  handleSearchParamChange
+} from '~/utils/urlSeachParamsHelpers'
+import { SubmitButton } from '~/components/form/SubmitButton'
+
+const PAGE_URL = '/wow/shortage-predictor'
+
+const defaultFormValues = {
+  desiredAvgPrice: '20',
+  desiredSalesPerDay: '200',
+  itemQuality: '1',
+  itemClass: '-1',
+  itemSubClass: '-1',
+  region: 'NA',
+  homeRealmName: '3678---Thrall',
+  desiredPriceVsAvgPercent: '120',
+  desiredQuantityVsAvgPercent: '50'
+}
 
 const inputMap: Record<keyof ShortagePredictorProps, string> = {
-  homeRealmName: 'Home Realm Name',
-  region: 'Region',
-  desiredAvgPrice: 'Average Price',
-  desiredSalesPerDay: 'Sales Per Day',
-  itemQuality: 'Quality',
-  itemClass: 'Item Class',
-  itemSubClass: 'Item Sub Class',
-  desiredPriceVsAvgPercent: 'Desired Current Price Percent vs Average Price',
-  desiredQuantityVsAvgPercent:
-    'Desired Current Quantity Percent vs Average Quantity'
+  desiredAvgPrice: 'Minimum Desired Average Price',
+  desiredSalesPerDay: 'Minimum Desired Sales Per Day',
+  itemQuality: 'Item Quality',
+  itemClass: 'Item Category',
+  itemSubClass: 'Item Sub Category',
+  region: 'Select your region',
+  homeRealmName: 'Search for server by name',
+  desiredPriceVsAvgPercent: 'Current Price Percent Above Average',
+  desiredQuantityVsAvgPercent: 'Current Market Quantity Percentage'
 }
 
 const pageTitle = 'Commodity Shortage Futures'
@@ -42,39 +64,21 @@ export const action: ActionFunction = async ({ request }) => {
   const formPayload = Object.fromEntries(formData)
 
   const validateFormData = z.object({
-    homeRealmName: z
-      .string()
-      .min(1)
-      .transform((value) => value.split('---')[1]),
-    region: z.union([z.literal('NA'), z.literal('EU')]),
     desiredAvgPrice: z
       .string()
       .min(1)
       .transform((value) => parseFloat(value) * 10000),
-    desiredSalesPerDay: z
+    desiredSalesPerDay: parseStringToNumber,
+    itemQuality: parseStringToNumber,
+    itemClass: parseStringToNumber,
+    itemSubClass: parseStringToNumber,
+    region: z.union([z.literal('NA'), z.literal('EU')]),
+    homeRealmName: z
       .string()
       .min(1)
-      .transform((value) => parseFloat(value)),
-    itemQuality: z
-      .string()
-      .min(1)
-      .transform((value) => parseInt(value, 10)),
-    itemClass: z
-      .string()
-      .min(1)
-      .transform((value) => parseInt(value, 10)),
-    itemSubClass: z
-      .string()
-      .min(1)
-      .transform((value) => parseInt(value, 10)),
-    desiredPriceVsAvgPercent: z
-      .string()
-      .min(1)
-      .transform((value) => parseInt(value, 10)),
-    desiredQuantityVsAvgPercent: z
-      .string()
-      .min(1)
-      .transform((value) => parseInt(value, 10))
+      .transform((value) => value.split('---')[1]),
+    desiredPriceVsAvgPercent: parseStringToNumber,
+    desiredQuantityVsAvgPercent: parseStringToNumber
   })
 
   const validInput = validateFormData.safeParse(formPayload)
@@ -101,12 +105,70 @@ type ActionResponse = PredictionResponse | { exception: string } | {}
 export const loader: LoaderFunction = async ({ request }) => {
   const { getWoWSessionData } = await getUserSessionData(request)
   const { server, region } = getWoWSessionData()
-  return json({ wowRealm: server, wowRegion: region })
+
+  const params = new URL(request.url).searchParams
+
+  const validateFormData = z.object({
+    desiredAvgPrice: z
+      .string()
+      .min(1)
+      .transform((value) => parseFloat(value) * 10000),
+    desiredSalesPerDay: parseStringToNumber,
+    itemQuality: parseStringToNumber,
+    itemClass: parseStringToNumber,
+    itemSubClass: parseStringToNumber,
+    region: z.union([z.literal('NA'), z.literal('EU')]),
+    homeRealmName: z
+      .object({
+        id: z.number(),
+        name: z.string()
+      })
+      .transform((value) => `${value.id}---${value.name}`),
+    desiredPriceVsAvgPercent: parseStringToNumber,
+    desiredQuantityVsAvgPercent: parseStringToNumber
+  })
+
+  const input = {
+    desiredAvgPrice:
+      params.get('desiredAvgPrice') ||
+      defaultFormValues.desiredAvgPrice.toString(),
+    desiredSalesPerDay:
+      params.get('desiredSalesPerDay') ||
+      defaultFormValues.desiredSalesPerDay.toString(),
+    itemQuality:
+      params.get('itemQuality') || defaultFormValues.itemQuality.toString(),
+    itemClass:
+      params.get('itemClass') || defaultFormValues.itemClass.toString(),
+    itemSubClass:
+      params.get('itemSubClass') || defaultFormValues.itemSubClass.toString(),
+    region: params.get('region') || region,
+    homeRealmName: `${server.id}---${server.name}`,
+    desiredPriceVsAvgPercent:
+      params.get('desiredPriceVsAvgPercent') ||
+      defaultFormValues.desiredPriceVsAvgPercent.toString(),
+    desiredQuantityVsAvgPercent:
+      params.get('desiredQuantityVsAvgPercent') ||
+      defaultFormValues.desiredQuantityVsAvgPercent.toString()
+  }
+
+  const validInput = validateFormData.safeParse(input)
+  if (validInput.success) {
+    const responseData = {
+      ...validInput.data
+    }
+    return json(responseData)
+  }
+
+  return json(defaultFormValues)
 }
 
 const Index = () => {
   const transition = useNavigation()
-  const { wowRealm, wowRegion } = useLoaderData<WoWLoaderData>()
+
+  const loaderData = useLoaderData<typeof defaultFormValues>()
+  const [searchParams, setSearchParams] = useState<typeof defaultFormValues>({
+    ...loaderData
+  })
   const results = useActionData<ActionResponse>()
 
   const loading = transition.state === 'submitting'
@@ -117,9 +179,17 @@ const Index = () => {
     }
   }
 
+  const handleFormChange = (
+    name: keyof typeof defaultFormValues,
+    value: string
+  ) => {
+    handleSearchParamChange(name, value)
+    setSearchParams((prev) => ({ ...prev, [name]: value }))
+  }
+
   if (results) {
     if (!Object.keys(results)) {
-      return <NoResults href="/" title="No results found" />
+      return <NoResults href={PAGE_URL} title="No results found" />
     }
 
     if ('data' in results) {
@@ -135,51 +205,95 @@ const Index = () => {
         description={pageDescription}
         onClick={onSubmit}
         error={error}
-        loading={loading}>
+        loading={loading}
+        action={getActionUrl(PAGE_URL, searchParams)}>
+        <div className="pt-2">
+          <div className="flex justify-end mb-2">
+            <SubmitButton
+              title="Share this search!"
+              onClick={handleCopyButton}
+              type="button"
+            />
+          </div>
+        </div>
         <div className="pt-2 md:pt-4">
           <InputWithLabel
-            defaultValue={20}
+            defaultValue={loaderData.desiredAvgPrice}
+            labelTitle={inputMap.desiredAvgPrice}
             type="number"
-            labelTitle="Minimum Desired Avg Price"
             inputTag="Gold"
             name="desiredAvgPrice"
             min={0}
             step={0.01}
             toolTip="Find items that on average sell for this amount of gold or more."
+            onChange={(e) =>
+              handleFormChange('desiredAvgPrice', e.target.value)
+            }
           />
           <InputWithLabel
-            defaultValue={200}
+            defaultValue={loaderData.desiredSalesPerDay}
+            labelTitle={inputMap.desiredSalesPerDay}
             type="number"
-            labelTitle="Minimum Desired Sales per Day"
             inputTag="Sales"
             name="desiredSalesPerDay"
             min={0}
             toolTip="Finds items that have this many sales per day."
+            onChange={(e) =>
+              handleFormChange('desiredSalesPerDay', e.target.value)
+            }
           />
-          <ItemQualitySelect />
-          <ItemClassSelect />
+          <ItemQualitySelect
+            defaultValue={loaderData.itemQuality}
+            onChange={(value) => handleFormChange('itemQuality', value)}
+          />
+          <ItemClassSelect
+            itemClass={parseInt(loaderData.itemClass)}
+            itemSubClass={parseInt(loaderData.itemSubClass)}
+            onChange={(itemClassValue, itemSubClassValue) => {
+              handleFormChange('itemClass', itemClassValue.toString())
+              handleFormChange('itemSubClass', itemSubClassValue.toString())
+            }}
+          />
           <RegionAndServerSelect
             serverSelectFormName="homeRealmName"
-            region={wowRegion}
-            defaultRealm={wowRealm}
+            region={loaderData.region as WoWServerRegion}
+            defaultRealm={
+              {
+                id: parseInt(loaderData.homeRealmName.split('---')[0], 10),
+                name: loaderData.homeRealmName.split('---')[1]
+              } as WoWServerData
+            }
+            regionOnChange={(region) => handleFormChange('region', region)}
+            onServerSelectChange={(realm) =>
+              handleFormChange(
+                'homeRealmName',
+                realm ? `${realm.id}---${realm.name}` : ''
+              )
+            }
           />
           <InputWithLabel
-            defaultValue={120}
+            defaultValue={loaderData.desiredPriceVsAvgPercent}
             type="number"
-            labelTitle="Current Price Percent Above Average"
+            labelTitle={inputMap.desiredPriceVsAvgPercent}
             inputTag="%"
             name="desiredPriceVsAvgPercent"
             min={0}
             toolTip="What is the maximum price spike to look for? 120% is to only find item that are at most 20% above the average price, so you get there before prices increase. After prices increase too much competition will show up preventing the price from going higher."
+            onChange={(e) =>
+              handleFormChange('desiredPriceVsAvgPercent', e.target.value)
+            }
           />
           <InputWithLabel
-            defaultValue={50}
+            defaultValue={loaderData.desiredQuantityVsAvgPercent}
             type="number"
-            labelTitle="Current Market Quantity Percentage"
+            labelTitle={inputMap.desiredQuantityVsAvgPercent}
             inputTag="%"
             name="desiredQuantityVsAvgPercent"
             min={0}
             toolTip="How much of the market quantity is left? For 50% we want to find items which only have 50% of their average quantity remaining in stock."
+            onChange={(e) =>
+              handleFormChange('desiredQuantityVsAvgPercent', e.target.value)
+            }
           />
         </div>
       </SmallFormContainer>


### PR DESCRIPTION
## Why

Brief description/reasons for PR

This PR introduces the ability to handle URL search parameters in the `wow.shortage-predictor` route. It enhances the user experience by allowing users to share links with predefined search parameters, enabling quick access to specific predictions without manually setting the parameters each time.

## Related Tickets

N/A


## Considerations

N/A

