### PR TITLE
add checkbox for 'dc_only' option to FFXIV price alert generator

### DIFF
--- a/app/routes/_public.price-sniper.tsx
+++ b/app/routes/_public.price-sniper.tsx
@@ -1,7 +1,11 @@
 import { useLoaderData } from '@remix-run/react'
 import { PageWrapper } from '~/components/Common'
 import SmallFormContainer from '~/components/form/SmallFormContainer'
-import type { LoaderFunction } from '@remix-run/cloudflare'
+import type {
+  LinksFunction,
+  LoaderFunction,
+  MetaFunction
+} from '@remix-run/cloudflare'
 import { json } from '@remix-run/cloudflare'
 import { getSession } from '~/sessions'
 import { validateWorldAndDataCenter } from '~/utils/locations'
@@ -11,6 +15,7 @@ import Label from '~/components/form/Label'
 import HQCheckbox from '~/components/form/HQCheckbox'
 import CodeBlock from '~/components/Common/CodeBlock'
 import ItemSelect from '~/components/form/select/ItemSelect'
+import CheckBox from '~/components/form/CheckBox'
 
 // Overwrite default meta in the root.tsx
 export const meta: MetaFunction = () => {
@@ -76,10 +81,16 @@ const Index = () => {
   const [subForm, setSubForm] = useState<SubFormItem | null>(null)
   const [error, setError] = useState<string | undefined>(undefined)
   const [isPrice, setIsPrice] = useState(true)
+  const [dcOnly, setDcOnly] = useState(false)
 
   const jsonToDisplay = `{\n  "home_server": "${
     jsonData.server
-  }"${parseJSONInput(jsonData.userAuctions, isPrice)}\n}`
+  }",\n  "user_auctions": [${jsonData.userAuctions
+    .map(
+      ({ itemID, price, desiredState, hq }) =>
+        `\n    { "itemID": ${itemID}, "price": ${price}, "desired_state": "${desiredState}", "hq": ${hq} }`
+    )
+    .join(',')}\n  ]${dcOnly ? ',\n  "dc_only": true' : ''}\n}`
 
   const isPriceValue = isPrice ? 'price' : 'quantity'
 
@@ -258,6 +269,20 @@ const Index = () => {
                     })
                   }
                 />
+                <div className="my-2 flex items-center">
+                  <Label
+                    htmlFor="dc-only"
+                    className="font-medium text-gray-700 dark:text-gray-200">
+                    DC Only
+                  </Label>
+                  <CheckBox
+                    id="dc-only"
+                    checked={dcOnly}
+                    onChange={() => setDcOnly(!dcOnly)}
+                    className="ml-2 rounded p-1"
+                    labelTitle=""
+                  />
+                </div>
               </div>
             )}
           </div>

--- a/app/routes/queries._index.tsx
+++ b/app/routes/queries._index.tsx
@@ -3,6 +3,7 @@ import {
   ChartSquareBarIcon,
   PencilAltIcon
 } from '@heroicons/react/outline'
+import type { MetaFunction, LinksFunction } from '@remix-run/cloudflare'
 import Banner from '~/components/Common/Banner'
 import TileLink from '~/components/Common/TileLink'
 
@@ -146,9 +147,9 @@ export default function Index() {
           ffxiv mod, ffxiv mogstation, ffxiv fashion report, fashion report
           ffxiv, ffxiv forums, ffxiv housing, ffxiv maintenance, ffxiv market
           board, ffxiv patch notes, final fantasy 14 reddit, ffxiv fanfest,
-          ffxiv msq list, ffxiv character search, ffxiv fafnir,
-          universalis ffxiv, ffxiv maintenance jan 15, ffxiv
-          relic weapons, r ffxiv, relic weapons ffxiv, character search ffxiv
+          ffxiv msq list, ffxiv character search, ffxiv fafnir, universalis
+          ffxiv, ffxiv maintenance jan 15, ffxiv relic weapons, r ffxiv, relic
+          weapons ffxiv, character search ffxiv
         </p>
       </main>
     </>


### PR DESCRIPTION
## Why

Add a checkbox to the FFXIV price alert generator for the "dc_only" option to enhance user customization and filtering capabilities.

## Related Tickets

* Closes https://github.com/ff14-advanced-market-search/saddlebag-with-pockets/issues/398

## Considerations

Ensure the new checkbox integrates seamlessly with existing functionality and does not introduce any regressions.

