### PR TITLE
Extended history

### DIFF
--- a/app/components/navigation/sidebar/Sidebar.tsx
+++ b/app/components/navigation/sidebar/Sidebar.tsx
@@ -156,6 +156,11 @@ const navGroups: Array<{
         icon: ChartSquareBarIcon
       },
       {
+        name: 'Extended Sale History',
+        href: '/ffxiv/extended-history',
+        icon: ChartSquareBarIcon
+      },
+      {
         name: 'Self Purchase Records',
         href: 'ffxiv/self-purchase',
         icon: ChartSquareBarIcon

--- a/app/routes/ffxiv.extended-history.tsx
+++ b/app/routes/ffxiv.extended-history.tsx
@@ -194,7 +194,7 @@ const FFXIVSaleHistory = () => {
       <>
         <div className="py-3">
           <SmallFormContainer
-            title="Find Sale History"
+            title="Find Extened Sale History of Last 1800 Sales"
             onClick={onSubmit}
             error={error}
             loading={transition.state === 'submitting'}
@@ -223,7 +223,7 @@ const FFXIVSaleHistory = () => {
               sortingOrder={sortingOrder}
               columnList={columnList}
               title="Sale History"
-              description="A detailed history of item sales"
+              description="A detailed history of last 1800 item sales"
               mobileColumnList={mobileColumnList}
               columnSelectOptions={columnSelectOptions}
             />

--- a/app/routes/queries._index.tsx
+++ b/app/routes/queries._index.tsx
@@ -93,6 +93,13 @@ const ffxivPages = [
     Icon: ChartSquareBarIcon
   },
   {
+    name: 'Extened Sale History',
+    description:
+      'See extended sale history of last 1800 sales on any FFXIV item.',
+    Icon: ChartSquareBarIcon,
+    href: '/ffxiv/extended-history'
+  },
+  {
     name: 'Item History Statistics and Graphs',
     description:
       'Helps you find if an item is worth selling or not based on past sale history. Can tell you the best price to sell at, best time of day to sell, best stack size to sell at and more!',


### PR DESCRIPTION
@coderabbitai I need help finishing this one, it makes a successful request, but it cant turn this into a table.

Heres an example of a PR for a page that works.

https://github.com/ff14-advanced-market-search/saddlebag-with-pockets/pull/288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a feature for retrieving and displaying detailed sale history data for FFXIV items.
  - Added a new "Extended Sale History" option in the navigation sidebar for direct access to sale history information.

- **Enhancements**
  - Improved navigation with a dedicated link to view the extended sale history of the last 1800 sales on any FFXIV item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->