### PR TITLE
fix(ui): Stretch table to full width in queries/full-scan

### DIFF
--- a/app/routes/queries.full-scan.tsx
+++ b/app/routes/queries.full-scan.tsx
@@ -111,8 +111,8 @@ export const loader: LoaderFunction = ({ request }) => {
       : undefined,
     filters: url.searchParams.has('filters')
       ? decodeURIComponent(url.searchParams.get('filters') as string)
-          ?.split(',')
-          .map((str) => parseInt(str))
+        ?.split(',')
+        .map((str) => parseInt(str))
       : undefined,
     hQChecked: url.searchParams.has('hQChecked')
       ? url.searchParams.get('hQChecked') === 'true'
@@ -167,33 +167,35 @@ const Index = () => {
     !displayNoResultsPage && results && 'data' in results
 
   return (
-    <main className="flex-1">
-      <div className="py-6">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8">
+    <main className="flex-1 w-full">
+      <div className="py-6 w-full">
+        <div className="w-full px-4 sm:px-6 md:px-8">
           <h1 className="text-2xl font-semibold text-green-900 py-6 dark:text-gray-100">
             FFXIV Import Search
           </h1>
           {fullScan && !results && (
             <PreviousResultsLink to="/queries/previous-search?query=fullScan" />
           )}
-          <FullScanForm
-            loading={transition.state === 'submitting'}
-            onClick={onSubmit}
-            error={
-              results && 'exception' in results ? results.exception : undefined
-            }
-            defaultHours={searchParams.hours}
-            defaultSalesAmount={searchParams.salesAmount}
-            defaultROI={searchParams.ROI}
-            defaultMinimumStackSize={searchParams.minimumStackSize}
-            defaultMinimumProfitAmount={searchParams.minimumProfitAmount}
-            defaultPricePerUnit={searchParams.pricePerUnit}
-            defaultFilters={searchParams.filters}
-            defaultHQChecked={searchParams.hQChecked}
-            defaultRegionWideChecked={searchParams.regionWideChecked}
-            defaultIncludeVendorChecked={searchParams.includeVendorChecked}
-            defaultOutOfStockChecked={searchParams.outOfStockChecked}
-          />
+          <div className="w-full max-w-7xl mx-auto">
+            <FullScanForm
+              loading={transition.state === 'submitting'}
+              onClick={onSubmit}
+              error={
+                results && 'exception' in results ? results.exception : undefined
+              }
+              defaultHours={searchParams.hours}
+              defaultSalesAmount={searchParams.salesAmount}
+              defaultROI={searchParams.ROI}
+              defaultMinimumStackSize={searchParams.minimumStackSize}
+              defaultMinimumProfitAmount={searchParams.minimumProfitAmount}
+              defaultPricePerUnit={searchParams.pricePerUnit}
+              defaultFilters={searchParams.filters}
+              defaultHQChecked={searchParams.hQChecked}
+              defaultRegionWideChecked={searchParams.regionWideChecked}
+              defaultIncludeVendorChecked={searchParams.includeVendorChecked}
+              defaultOutOfStockChecked={searchParams.outOfStockChecked}
+            />
+          </div>
           {displayNoResultsPage && (
             <NoResults>
               A quick suggestion would be expanding the{' '}
@@ -202,7 +204,11 @@ const Index = () => {
               <span className={`font-bold`}>Sale Amount</span>.
             </NoResults>
           )}
-          {displayResultsTable && <Results rows={results.data} />}
+          {displayResultsTable && (
+            <div className="w-full">
+              <Results rows={results.data} />
+            </div>
+          )}
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Changes Made
This PR modifies the table layout on the queries/full-scan page to stretch to full width while keeping the form with fixed width.