### PR TITLE
Fix option persistence: Implement session and browser cookies

### DIFF
--- a/app/requests/client/config.ts
+++ b/app/requests/client/config.ts
@@ -9,3 +9,4 @@ export const address = defaultAddress
 //     : defaultAddress
 
 export const UserAgent = 'Saddlebag/1.0'
+export const defaultMaxAge = 60 * 60 * 24 * 365 // 1 year in seconds

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -53,6 +53,7 @@ import {
   getWoWRealmDataFromLocalStorage,
   setWoWRealmDataInLocalStorage
 } from './redux/localStorage/wowRealmHelpers'
+import { setCookie } from './utils/cookies'
 
 export const ErrorBoundary = () => {
   return (
@@ -153,10 +154,19 @@ export const action: ActionFunction = async ({ request }) => {
   session.set(WOW_REALM_NAME, server.name)
   session.set(WOW_REALM_ID, server.id)
 
+  const cookies = [
+    setCookie(DATA_CENTER, data_center),
+    setCookie(FF14_WORLD, world),
+    setCookie(WOW_REALM_ID, server.id.toString()),
+    setCookie(WOW_REALM_NAME, server.name),
+    setCookie(WOW_REGION, region)
+  ]
+
   return redirect('/', {
-    headers: {
-      'Set-Cookie': await commitSession(session)
-    }
+    headers: [
+      ['Set-Cookie', await commitSession(session)],
+      ...cookies.map((cookie) => ['Set-Cookie', cookie] as [string, string])
+    ]
   })
 }
 

--- a/app/routes/_public.options.tsx
+++ b/app/routes/_public.options.tsx
@@ -34,6 +34,7 @@ import RegionAndServerSelect from '~/components/form/WoW/RegionAndServerSelect'
 import SelectDCandWorld from '~/components/form/select/SelectWorld'
 import type { WoWServerData, WoWServerRegion } from '~/requests/WoW/types'
 import { PageWrapper } from '~/components/Common'
+import { setCookie } from '~/utils/cookies'
 
 // Overwrite default meta in the root.tsx
 export const meta: MetaFunction = () => {
@@ -90,11 +91,20 @@ export const action: ActionFunction = async ({ request }) => {
   session.set(WOW_REALM_NAME, server.name)
   session.set(WOW_REGION, region)
 
+  const cookies = [
+    setCookie(DATA_CENTER, data_center),
+    setCookie(FF14_WORLD, world),
+    setCookie(WOW_REALM_ID, server.id.toString()),
+    setCookie(WOW_REALM_NAME, server.name),
+    setCookie(WOW_REGION, region)
+  ]
+
   // Set the new option, yeet back to index (but save against session data within the cookie)
   return redirect('/', {
-    headers: {
-      'Set-Cookie': await commitSession(session)
-    }
+    headers: [
+      ['Set-Cookie', await commitSession(session)],
+      ...cookies.map((cookie) => ['Set-Cookie', cookie] as [string, string])
+    ]
   })
 }
 

--- a/app/sessions/index.ts
+++ b/app/sessions/index.ts
@@ -2,6 +2,7 @@ import type { Session } from '@remix-run/cloudflare'
 import { createCookieSessionStorage } from '@remix-run/cloudflare'
 import { validateWorldAndDataCenter } from '~/utils/locations'
 import { validateServerAndRegion } from '~/utils/WoWServers'
+import { defaultMaxAge } from '~/requests/client/config'
 
 export const DATA_CENTER = 'data_center'
 export const FF14_WORLD = 'world'
@@ -16,7 +17,8 @@ const { getSession, commitSession, destroySession } =
       secure: process.env.NODE_ENV === 'production',
       httpOnly: true,
       sameSite: 'lax',
-      path: '/'
+      path: '/',
+      maxAge: defaultMaxAge
     }
   })
 

--- a/app/sessions/index.ts
+++ b/app/sessions/index.ts
@@ -3,6 +3,7 @@ import { createCookieSessionStorage } from '@remix-run/cloudflare'
 import { validateWorldAndDataCenter } from '~/utils/locations'
 import { validateServerAndRegion } from '~/utils/WoWServers'
 import { defaultMaxAge } from '~/requests/client/config'
+import type { WoWServerRegion } from '~/requests/WoW/types'
 
 export const DATA_CENTER = 'data_center'
 export const FF14_WORLD = 'world'
@@ -50,13 +51,47 @@ const getUserWoWSessionData = (session: Session) => {
 
 async function getUserSessionData(request: Request) {
   const session = await getSession(request.headers.get('Cookie'))
+  const cookieHeader = request.headers.get('Cookie') || ''
+
+  const getCookieValue = (name: string) => {
+    const match = cookieHeader.match(new RegExp(`(^| )${name}=([^;]+)`))
+    return match ? match[2] : undefined
+  }
+
+  const getFF14Data = () => {
+    const worldCookie = getCookieValue(FF14_WORLD)
+    const dataCenterCookie = getCookieValue(DATA_CENTER)
+
+    if (worldCookie && dataCenterCookie) {
+      return validateWorldAndDataCenter(worldCookie, dataCenterCookie)
+    }
+
+    return getFF14WorldAndDataCenter(session)
+  }
+
+  const getWoWData = () => {
+    const regionCookie = getCookieValue(WOW_REGION)
+    const realmIdCookie = getCookieValue(WOW_REALM_ID)
+    const realmNameCookie = getCookieValue(WOW_REALM_NAME)
+
+    if (regionCookie && realmIdCookie && realmNameCookie) {
+      return validateServerAndRegion(
+        regionCookie as WoWServerRegion,
+        realmIdCookie,
+        realmNameCookie
+      )
+    }
+
+    return getUserWoWSessionData(session)
+  }
+
   return {
-    getWorld: () => getFF14WorldAndDataCenter(session).world,
-    getDataCenter: () => getFF14WorldAndDataCenter(session).data_center,
-    getWoWSessionData: () => getUserWoWSessionData(session),
+    getWorld: () => getFF14Data().world,
+    getDataCenter: () => getFF14Data().data_center,
+    getWoWSessionData: () => getWoWData(),
     getAllUserSessionData: () => ({
-      ...getFF14WorldAndDataCenter(session),
-      ...getUserWoWSessionData(session)
+      ...getFF14Data(),
+      ...getWoWData()
     })
   }
 }

--- a/app/utils/cookies.ts
+++ b/app/utils/cookies.ts
@@ -1,0 +1,10 @@
+import { defaultMaxAge } from '~/requests/client/config'
+
+export function setCookie(
+  name: string,
+  value: string,
+  options: { maxAge?: number; path?: string } = {}
+) {
+  const { maxAge = defaultMaxAge, path = '/' } = options
+  return `${name}=${encodeURIComponent(value)}; Max-Age=${maxAge}; Path=${path}; HttpOnly; Secure; SameSite=Lax`
+}


### PR DESCRIPTION
## Problem

Users were experiencing loss of their selected options upon browser restart or after some time. This was causing inconvenience and requiring users to repeatedly set their preferences.

## Solution

To address this issue, I implemented a persistent session cookie with a long-lived max age. Additionally, I introduced browser cookies to store user options, providing a dual storage mechanism for improved persistence.

## Changes Made

1. Added default max age for session cookies:
   - Defined `defaultMaxAge` (1 year) in `app/requests/client/config.ts`
   - Applied this max age to session cookies in `app/sessions/index.ts`

2. Implemented browser cookies for user options:
   - Created `setCookie` utility function in `app/utils/cookies.ts`
   - Updated `app/root.tsx` and `app/routes/_public.options.tsx` to set browser cookies alongside session cookies

3. Enhanced session data retrieval:
   - Modified `getUserSessionData` in `app/sessions/index.ts` to prioritize browser cookies over session data

4. Updated relevant files:
   - `app/root.tsx`
   - `app/routes/_public.options.tsx`
   - `app/sessions/index.ts`
   - `app/utils/cookies.ts`

These changes ensure that user preferences persist across browser sessions and for an extended period, significantly improving the user experience by maintaining selected options.