### PR TITLE
Implement lazy loading for third-party JavaScript to improve page load speeds

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -244,35 +244,49 @@ function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      // Load Google Tag Manager
+      ;(function (w, d, s, l, i) {
+        w[l] = w[l] || []
+        w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' })
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : ''
+        j.async = true
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl
+        f.parentNode.insertBefore(j, f)
+      })(window, document, 'script', 'dataLayer', 'GTM-WH4KFG5')
+
+      // Load Ezoic script
+      const script = document.createElement('script')
+      script.src = '//www.ezojs.com/ezoic/sa.min.js'
+      script.async = true
+      document.body.appendChild(script)
+
+      script.onload = function () {
+        window.ezstandalone = window.ezstandalone || {}
+        ezstandalone.cmd = ezstandalone.cmd || []
+        ezstandalone.cmd.push(function () {
+          ezstandalone.define(118, 116)
+          ezstandalone.refresh()
+          ezstandalone.enable()
+          ezstandalone.display()
+        })
+      }
+    }, 2000) // Delay of 1000ms (1 second)
+
+    // Cleanup function to clear the timeout if the component unmounts
+    return () => clearTimeout(timer)
+  }, []) // Empty dependency array means this effect runs once after initial render
+
   return (
     <html lang="en" className={classNames(`h-full`, theme || '')}>
       <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','GTM-WH4KFG5');`
-          }}
-        />
         <Meta />
         <Links />
         <EnsureThemeApplied />
-        <script async src="//www.ezojs.com/ezoic/sa.min.js"></script>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `window.ezstandalone = window.ezstandalone || {};
-          ezstandalone.cmd = ezstandalone.cmd || [];
-          ezstandalone.cmd.push(function() {
-            ezstandalone.define(118,116);
-            ezstandalone.refresh();
-            ezstandalone.enable();
-            ezstandalone.display();
-        });`
-          }}
-        />
       </head>
       <body className={`h-full bg-gray-100 dark:bg-slate-800`}>
         <noscript>


### PR DESCRIPTION
## Changes
This PR introduces lazy loading for third-party JavaScript, specifically advertisements and Google Analytics, to improve page load speeds. The changes include:

- Delaying the loading of third-party scripts by 2 seconds after the initial app rendering
- Implementing this delay in the `App` component within `app/root.tsx`
- Using `setTimeout` to manage the delayed loading of Google Tag Manager and Ezoic scripts
- Ensuring that the scripts are loaded asynchronously to minimize impact on app performance

## Motivation
These changes aim to improve the initial load time and overall performance of our application, especially on mobile devices. This is crucial because:

1. Our mobile load speeds currently need improvement
2. Google's mobile-first indexing initiative will exclusively crawl and index all sites using its mobile Googlebot after July 5, 2024
3. We want to keep ads while improving performance

This should result in:
- Faster perceived load time for users
- Better Core Web Vitals scores
- Improved mobile experience
- Better indexing by Google post July 2024

## Related Issues
Addresses #507 - Improve page load speeds