### PR TITLE
disable ezoic for new ad tests

### DIFF
--- a/app/components/navigation/sidebar/Sidebar.tsx
+++ b/app/components/navigation/sidebar/Sidebar.tsx
@@ -684,7 +684,7 @@ export const Sidebar: FC<Props> = ({ children, data }) => {
                 Entertainment, Inc.
                 <br />© BLIZZARD ENTERTAINMENT, INC. All Rights Reserved.
               </p>
-              <div id="ezoic-pub-ad-placeholder-118" />
+              {/* <div id="ezoic-pub-ad-placeholder-118" /> */}
             </nav>
           </div>
         </div>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -274,22 +274,21 @@ function App() {
         // hubspotScript.defer = true
         // document.body.appendChild(hubspotScript)
 
-        // Load Ezoic script
-        const ezoicScript = document.createElement('script')
-        ezoicScript.src = '//www.ezojs.com/ezoic/sa.min.js'
-        ezoicScript.async = true
-        document.body.appendChild(ezoicScript)
-
-        ezoicScript.onload = function () {
-          window.ezstandalone = window.ezstandalone || {}
-          ezstandalone.cmd = ezstandalone.cmd || []
-          ezstandalone.cmd.push(function () {
-            ezstandalone.define(118, 116)
-            ezstandalone.refresh()
-            ezstandalone.enable()
-            ezstandalone.display()
-          })
-        }
+        // // Load Ezoic script
+        // const ezoicScript = document.createElement('script')
+        // ezoicScript.src = '//www.ezojs.com/ezoic/sa.min.js'
+        // ezoicScript.async = true
+        // document.body.appendChild(ezoicScript)
+        // ezoicScript.onload = function () {
+        //   window.ezstandalone = window.ezstandalone || {}
+        //   ezstandalone.cmd = ezstandalone.cmd || []
+        //   ezstandalone.cmd.push(function () {
+        //     ezstandalone.define(118, 116)
+        //     ezstandalone.refresh()
+        //     ezstandalone.enable()
+        //     ezstandalone.display()
+        //   })
+        // }
       })
     }, 3000)
 


### PR DESCRIPTION
ref: https://github.com/ff14-advanced-market-search/saddlebag-with-pockets/issues/540

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Disabled an advertisement element in the navigation interface to streamline the display.
  - Disabled the external advertisement script loading, ensuring smoother performance while keeping the option to reactivate in the future.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->