### PR TITLE
wow weekly data now uses end dates

### DIFF
--- a/app/components/WoW/ImportSection.tsx
+++ b/app/components/WoW/ImportSection.tsx
@@ -6,6 +6,9 @@ interface ImportData {
   start_year?: number
   start_month?: number
   start_day?: number
+  end_year?: number
+  end_month?: number
+  end_day?: number
   price_groups?: PriceGroup[]
 }
 

--- a/app/components/WoW/RequestDataSection.tsx
+++ b/app/components/WoW/RequestDataSection.tsx
@@ -5,6 +5,7 @@ interface RequestDataSectionProps {
   data: WeeklyPriceGroupDeltaResponse
   wowRegion: string
   startDate: string
+  endDate: string
   darkMode: boolean
 }
 
@@ -17,8 +18,26 @@ export default function RequestDataSection({
   data,
   wowRegion,
   startDate,
+  endDate,
   darkMode
 }: RequestDataSectionProps) {
+  const requestData = {
+    region: wowRegion,
+    start_year: Number.parseInt(startDate.slice(0, 4)),
+    start_month: Number.parseInt(startDate.slice(4, 6)),
+    start_day: Number.parseInt(startDate.slice(6, 8)),
+    end_year: Number.parseInt(endDate.slice(0, 4)),
+    end_month: Number.parseInt(endDate.slice(4, 6)),
+    end_day: Number.parseInt(endDate.slice(6, 8)),
+    price_groups: Object.entries(data).map(([name, groupData]) => ({
+      name,
+      item_ids: Object.keys(groupData.item_data).map((id: string) =>
+        Number.parseInt(id)
+      ),
+      categories: []
+    }))
+  }
+
   return (
     <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow mt-4">
       <h3
@@ -31,23 +50,7 @@ export default function RequestDataSection({
         <CodeBlock
           title="Request data used for this analysis"
           buttonTitle="Copy"
-          codeString={JSON.stringify(
-            {
-              region: wowRegion,
-              start_year: Number.parseInt(startDate.slice(0, 4)),
-              start_month: Number.parseInt(startDate.slice(4, 6)),
-              start_day: Number.parseInt(startDate.slice(6, 8)),
-              price_groups: Object.entries(data).map(([name, groupData]) => ({
-                name,
-                item_ids: Object.keys(groupData.item_data).map((id: string) =>
-                  Number.parseInt(id)
-                ),
-                categories: []
-              }))
-            },
-            null,
-            2
-          )}
+          codeString={JSON.stringify(requestData, null, 2)}
           onClick={() => {
             alert('Copied to clipboard!')
           }}>

--- a/app/components/WoW/RequestPreview.tsx
+++ b/app/components/WoW/RequestPreview.tsx
@@ -6,6 +6,9 @@ interface RequestPreviewProps {
   startYear: number
   startMonth: number
   startDay: number
+  endYear: number
+  endMonth: number
+  endDay: number
   priceGroups: PriceGroup[]
 }
 
@@ -18,6 +21,9 @@ interface RequestPreviewProps {
  * @param startYear - The starting year for the request data.
  * @param startMonth - The starting month for the request data.
  * @param startDay - The starting day for the request data.
+ * @param endYear - The ending year for the request data.
+ * @param endMonth - The ending month for the request data.
+ * @param endDay - The ending day for the request data.
  * @param priceGroups - An array of price group objects to include in the request.
  */
 export default function RequestPreview({
@@ -25,6 +31,9 @@ export default function RequestPreview({
   startYear,
   startMonth,
   startDay,
+  endYear,
+  endMonth,
+  endDay,
   priceGroups
 }: RequestPreviewProps) {
   const requestData = {
@@ -32,6 +41,9 @@ export default function RequestPreview({
     start_year: startYear,
     start_month: startMonth,
     start_day: startDay,
+    end_year: endYear,
+    end_month: endMonth,
+    end_day: endDay,
     price_groups: priceGroups
   }
 

--- a/app/requests/WoW/WeeklyPriceGroupDelta.ts
+++ b/app/requests/WoW/WeeklyPriceGroupDelta.ts
@@ -17,6 +17,9 @@ export interface WeeklyPriceGroupDeltaProps {
   start_year: number
   start_month: number
   start_day: number
+  end_year: number
+  end_month: number
+  end_day: number
   price_groups: PriceGroup[]
 }
 

--- a/app/routes/wow.weekly-price-group-delta.tsx
+++ b/app/routes/wow.weekly-price-group-delta.tsx
@@ -27,7 +27,7 @@ import GroupSelector from '~/components/WoW/GroupSelector'
 import DeltaChartContainer from '~/components/WoW/DeltaChartContainer'
 import PriceQuantityAnalysis from '~/components/WoW/PriceQuantityAnalysis'
 import RequestDataSection from '~/components/WoW/RequestDataSection'
-import DateInputs from '~/components/WoW/DateInputs'
+import DateRangeInputs from '~/components/FFXIV/DateRangeInputs'
 import ImportSection from '~/components/WoW/ImportSection'
 import PriceGroupsSection from '~/components/WoW/PriceGroupsSection'
 import RequestPreview from '~/components/WoW/RequestPreview'
@@ -109,6 +109,9 @@ export const action: ActionFunction = async ({ request }) => {
   const startYear = Number.parseInt(formData.get('startYear') as string)
   const startMonth = Number.parseInt(formData.get('startMonth') as string)
   const startDay = Number.parseInt(formData.get('startDay') as string)
+  const endYear = Number.parseInt(formData.get('endYear') as string)
+  const endMonth = Number.parseInt(formData.get('endMonth') as string)
+  const endDay = Number.parseInt(formData.get('endDay') as string)
   const priceGroups = JSON.parse(
     formData.get('priceGroups') as string
   ) as PriceGroup[]
@@ -119,6 +122,9 @@ export const action: ActionFunction = async ({ request }) => {
       start_year: startYear,
       start_month: startMonth,
       start_day: startDay,
+      end_year: endYear,
+      end_month: endMonth,
+      end_day: endDay,
       price_groups: priceGroups
     })
 
@@ -158,6 +164,9 @@ const Index = () => {
   const [startYear, setStartYear] = useState(2025)
   const [startMonth, setStartMonth] = useState(1)
   const [startDay, setStartDay] = useState(1)
+  const [endYear, setEndYear] = useState(new Date().getFullYear())
+  const [endMonth, setEndMonth] = useState(new Date().getMonth() + 1)
+  const [endDay, setEndDay] = useState(new Date().getDate())
   const [showErrorPopup, setShowErrorPopup] = useState(false)
 
   const pageTitle = `Weekly Price Group Delta Analysis - ${wowRealm.name} (${wowRegion})`
@@ -193,22 +202,35 @@ const Index = () => {
               if (data.start_year) setStartYear(data.start_year)
               if (data.start_month) setStartMonth(data.start_month)
               if (data.start_day) setStartDay(data.start_day)
+              if (data.end_year) setEndYear(data.end_year)
+              if (data.end_month) setEndMonth(data.end_month)
+              if (data.end_day) setEndDay(data.end_day)
               if (data.price_groups) setPriceGroups(data.price_groups)
             }}
           />
 
-          <DateInputs
+          <DateRangeInputs
             startYear={startYear}
             startMonth={startMonth}
             startDay={startDay}
-            onYearChange={setStartYear}
-            onMonthChange={setStartMonth}
-            onDayChange={setStartDay}
+            endYear={endYear}
+            endMonth={endMonth}
+            endDay={endDay}
+            onStartYearChange={setStartYear}
+            onStartMonthChange={setStartMonth}
+            onStartDayChange={setStartDay}
+            onEndYearChange={setEndYear}
+            onEndMonthChange={setEndMonth}
+            onEndDayChange={setEndDay}
             onError={(err) => {
               setError(err)
               setShowErrorPopup(!!err)
             }}
           />
+
+          <input type="hidden" name="endYear" value={endYear} />
+          <input type="hidden" name="endMonth" value={endMonth} />
+          <input type="hidden" name="endDay" value={endDay} />
 
           <PriceGroupsSection
             priceGroups={priceGroups}
@@ -231,6 +253,9 @@ const Index = () => {
             startYear={startYear}
             startMonth={startMonth}
             startDay={startDay}
+            endYear={endYear}
+            endMonth={endMonth}
+            endDay={endDay}
             priceGroups={priceGroups}
           />
         </form>
@@ -510,6 +535,7 @@ const Results = ({
             data={data}
             wowRegion={wowRegion}
             startDate={startDate}
+            endDate={endDate}
             darkMode={darkMode}
           />
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying an end date in the weekly price group delta analysis, allowing users to select a date range.
  - Updated the interface to use a date range input for both start and end dates.
  - Imported data and request previews now display and handle end date fields.

- **Enhancements**
  - Forms and data previews now include end date information for improved clarity and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->