### PR TITLE
Fix: Error popup now stays open for validation errors in Price Groups…

### DIFF
--- a/app/routes/wow.weekly-price-group-delta.tsx
+++ b/app/routes/wow.weekly-price-group-delta.tsx
@@ -161,13 +161,15 @@ const Index = () => {
   const actionData = useActionData<ActionResponse>()
   const [priceGroups, setPriceGroups] = useState<PriceGroup[]>([])
   const [error, setError] = useState<string | undefined>(undefined)
+  const [showErrorPopup, setShowErrorPopup] = useState(false)
+  const [localError, setLocalError] = useState<string | undefined>(undefined)
+  const [showLocalErrorPopup, setShowLocalErrorPopup] = useState(false)
   const [startYear, setStartYear] = useState(2025)
   const [startMonth, setStartMonth] = useState(1)
   const [startDay, setStartDay] = useState(1)
   const [endYear, setEndYear] = useState(new Date().getFullYear())
   const [endMonth, setEndMonth] = useState(new Date().getMonth() + 1)
   const [endDay, setEndDay] = useState(new Date().getDate())
-  const [showErrorPopup, setShowErrorPopup] = useState(false)
 
   const pageTitle = `Weekly Price Group Delta Analysis - ${wowRealm.name} (${wowRegion})`
 
@@ -196,7 +198,10 @@ const Index = () => {
         loading={transition.state === 'submitting'}
         error={error}
         onClick={(e) => e.preventDefault()}>
-        <form method="post" className="space-y-4 mb-4">
+        <form
+          method="post"
+          className="space-y-4 mb-4"
+          onSubmit={(e) => e.preventDefault()}>
           <ImportSection
             onImport={(data) => {
               if (data.start_year) setStartYear(data.start_year)
@@ -236,8 +241,8 @@ const Index = () => {
             priceGroups={priceGroups}
             onPriceGroupsChange={setPriceGroups}
             onError={(err) => {
-              setError(err)
-              setShowErrorPopup(!!err)
+              setLocalError(err)
+              setShowLocalErrorPopup(!!err)
             }}
             isSubmitting={transition.state === 'submitting'}
           />
@@ -261,9 +266,16 @@ const Index = () => {
         </form>
       </SmallFormContainer>
 
-      {/* Error Popup */}
+      {/* Error Popup for server errors */}
       {error && showErrorPopup && (
         <ErrorPopup error={error} onClose={() => setShowErrorPopup(false)} />
+      )}
+      {/* Error Popup for local validation errors */}
+      {localError && showLocalErrorPopup && (
+        <ErrorPopup
+          error={localError}
+          onClose={() => setShowLocalErrorPopup(false)}
+        />
       )}
     </PageWrapper>
   )


### PR DESCRIPTION
Fix implemented by Arash (Upwork).
I have sent proposal , Thank you

## What was fixed

- The error popup for validation errors in the Price Groups section would previously close immediately after appearing, 
/wow/weekly-price-group-delta

## How to test

- Go to the Price Groups section.
- Leave a required field empty and click 'Search Price Groups'.
- The error popup should appear and stay open until you close it or fix the error.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a separate error popup for local validation errors, distinct from server error notifications.

- **Bug Fixes**
  - Improved form submission handling to prevent unintended page reloads.

- **Style**
  - Updated UI to clearly differentiate between local and server error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->