### PR TITLE
update min default ilvl

### DIFF
--- a/app/routes/wow.ilvl-export-search.tsx
+++ b/app/routes/wow.ilvl-export-search.tsx
@@ -69,7 +69,7 @@ type SortByValue =
 
 const defaultFormValues = {
   itemId: '',
-  ilvl: 610,
+  ilvl: 670,
   populationWP: 3000,
   populationBlizz: 1,
   rankingWP: 90,

--- a/app/routes/wow.ilvl-shopping-list.tsx
+++ b/app/routes/wow.ilvl-shopping-list.tsx
@@ -117,7 +117,7 @@ export const loader: LoaderFunction = async ({ request }) => {
 
   const itemID = params.get('itemId')
   const maxPurchasePrice = params.get('maxPurchasePrice') || '10000000'
-  const desiredMinIlvl = params.get('desiredMinIlvl') || '610'
+  const desiredMinIlvl = params.get('desiredMinIlvl') || '670'
   const desiredStats = [
     ...new Set(
       params
@@ -196,7 +196,7 @@ const IlvlShoppingListComponent = () => {
   const transition = useNavigation()
   const [itemName, setItemName] = useState<string>('')
   const [maxPurchasePrice, setMaxPurchasePrice] = useState<string>('10000000')
-  const [desiredMinIlvl, setDesiredMinIlvl] = useState<string>('610')
+  const [desiredMinIlvl, setDesiredMinIlvl] = useState<string>('670')
   const [itemID, setItemID] = useState<string>('')
   const [selectedStats, setSelectedStats] = useState<ItemStat[]>([])
 
@@ -209,7 +209,7 @@ const IlvlShoppingListComponent = () => {
     const itemIdFromUrl = searchParams.get('itemId')
     const maxPurchasePriceFromUrl =
       searchParams.get('maxPurchasePrice') || '10000000'
-    const desiredMinIlvlFromUrl = searchParams.get('desiredMinIlvl') || '610'
+    const desiredMinIlvlFromUrl = searchParams.get('desiredMinIlvl') || '670'
     const desiredStatsFromUrl = searchParams.getAll(
       'desiredStats'
     ) as ItemStat[]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default item level threshold from 610 to 670 across item filters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->